### PR TITLE
Added Jet Energy Regression

### DIFF
--- a/AnalysisManager.cc
+++ b/AnalysisManager.cc
@@ -86,6 +86,37 @@ void AnalysisManager::AddSample(SampleContainer sample){
     samples.push_back(sample);
 }
 
+void AnalysisManager::AddBDT(BDTInfo bdt) {
+    bdtInfos.push_back(bdt);
+    SetupBDT(bdt);
+}
+
+void AnalysisManager::SetJet1EnergyRegression(BDTInfo reg1) {
+    jet1EnergyRegression = reg1;
+    jet1EnergyRegressionIsSet = true;
+    if(debug>10000) {
+        PrintBDTInfoValues(reg1);
+    }
+    SetupBDT(reg1);
+}
+void AnalysisManager::SetJet2EnergyRegression(BDTInfo reg2) {
+    jet2EnergyRegression = reg2;
+    jet2EnergyRegressionIsSet = true;
+    if(debug>10000) {
+        PrintBDTInfoValues(reg2);
+    }
+    SetupBDT(reg2);
+}
+
+void AnalysisManager::PrintBDTInfoValues(BDTInfo bdt) {
+    std::cout<<"Printing information for BDT "<<bdt.bdtname<<"..."<<std::endl;
+    for (unsigned int i=0; i<bdt.inputNames.size(); i++) {
+         std::cout<<"Input variable: "<<bdt.inputNames[i].c_str()<<", reference in tree: "<<bdt.localVarNames[i].c_str()<<", current value: "<<*f[bdt.localVarNames[i]]<<std::endl;
+     }
+     for (unsigned int i=0; i<bdt.inputSpectatorNames.size(); i++) {
+         std::cout<<"Spectator variable: "<<bdt.inputSpectatorNames[i].c_str()<<", reference in tree: "<<bdt.localSpectatorVarNames[i].c_str()<<", current value: "<<*f[bdt.localSpectatorVarNames[i]]<<std::endl;
+     }
+}
 
 Int_t AnalysisManager::GetEntry(Long64_t entry)
 {
@@ -204,7 +235,12 @@ void AnalysisManager::SetupNewBranch(std::string name, int type, int length, boo
         return;
     }
     //treeptr=outputTree;
-        
+    /*if(branchInfos.count(name) != 0) {
+        // branch already exists
+        std::cout<<Form("Attempting to setup new branch %s, but it already exists in the output tree!", name.c_str())<<std::endl;
+        return;
+    }*/   
+    
     if(debug>1000) {
         std::cout<<"SetupNewBranch "<<name<<std::endl;
         std::cout<<"treetype name type length val \t"<<treetype<<" "<<name<<" "<<type<<" "<<length<<" "<<val<<std::endl;
@@ -460,6 +496,7 @@ bool AnalysisManager::Analyze(){
             
 void AnalysisManager::FinishEvent(){
     //need to fill the tree, hist, or whatever here.
+   
     ofile->cd();
     outputTree->Fill();
     return;
@@ -475,15 +512,15 @@ void AnalysisManager::TermAnalysis() {
 
 
 // Set up all the BDT branches and configure the BDT's with the same input variables as used in training. Run before looping over events.
-void AnalysisManager::SetupBDT( ) {
+void AnalysisManager::SetupBDT(BDTInfo bdtInfo) {
 
     // let's do 8TeV_H125Sig_LFHFWjetsNewTTbarVVBkg as an example
-    if(debug>100){
-        thereader = new TMVA::Reader( "!Color:!Silent" );
-    } else {
-        thereader = new TMVA::Reader( "!Color:Silent" );
-    }
-    int bdtType = 0;
+    //if(debug>100){
+    //    thereader = new TMVA::Reader( "!Color:!Silent" );
+    //} else {
+    //    thereader = new TMVA::Reader( "!Color:Silent" );
+    //}
+    /*int bdtType = 0;
     if (bdtType == 0) {
         thereader->AddVariable("H.massCorr",                &testMass); 
         thereader->AddVariable("H.ptCorr",                  &H.ptCorr);
@@ -506,17 +543,23 @@ void AnalysisManager::SetupBDT( ) {
 
         thereader->BookMVA("BDT method","aux/TMVA_8TeV_H125Sig_LFHFWjetsNewTTbarVVBkg_newCuts4_BDT.weights.xml");
         //thereader->BookMVA("BDT method",bdtInfo.xmlFile);
+    }*/
+    //std::cout<<Form("Setting up variables for BDT %s", bdtInfo.bdtname)<<std::endl;
+    TMVA::Reader *thereader = bdtInfo.reader;
+    
+    for(unsigned int i=0; i<bdtInfo.inputNames.size(); i++) {
+        //std::cout<<Form("Adding variable to BDT: %s (localName = %s) ",bdtInfo.inputNames[i], bdtInfo.localVarNames[i])<<std::endl;
+        
+        bdtInfo.reader->AddVariable(bdtInfo.inputNames[i], f[bdtInfo.localVarNames[i]]);
     }
 
-    /*for (std::map<char*,Float_t&>::iterator it = bdtInfo.inputs.begin(); it != bdtInfo.inputs.end(); ++it) {
-        thereader->AddVariable(it->first, it->second);
+    for(unsigned int i=0; i<bdtInfo.inputSpectatorNames.size(); i++) {
+        //std::cout<<Form("Adding spectator variable to BDT: %s (localName = %s) ",bdtInfo.inputSpectatorNames[i], bdtInfo.localSpectatorVarNames[i])<<std::endl;
+        bdtInfo.reader->AddSpectator(bdtInfo.inputSpectatorNames[i], f[bdtInfo.localSpectatorVarNames[i]]);
     }
 
-    for (std::map<char*, Float_t&>::iterator it = bdtInfo.secInputs.begin(); it!= bdtInfo.secInputs.end(); ++it) {
-        thereader->AddSpectator(it->first, it->second);
-    }
 
-    thereader->BookMVA(bdtInfo.method, bdtInfo.xmlFile);*/
+    thereader->BookMVA(bdtInfo.bdtname, bdtInfo.xmlFile);
 
 }
 

--- a/AnalysisManager.h
+++ b/AnalysisManager.h
@@ -56,11 +56,18 @@ public :
     TTree                           *outputTree;    // what will be the condensed output tree
     TTree                           *settingsTree;  // contains analysis settings
     std::string                     outputTreeName;
-    TMVA::Reader                    *thereader;     // for evaluating the BDT
-    BDTInfo                         bdtInfo;
+    //TMVA::Reader                    *thereader;     // for evaluating the BDT
+    std::vector<BDTInfo>            bdtInfos;
+    BDTInfo                         jet1EnergyRegression;
+    BDTInfo                         jet2EnergyRegression;
+    bool                            jet1EnergyRegressionIsSet = false;
+    bool                            jet2EnergyRegressionIsSet = false;
     std::vector<SampleContainer>    samples; 
     SampleContainer*                cursample; 
     void                            AddSample(SampleContainer sample);
+    void                            AddBDT(BDTInfo bdtInfo);
+    void                            SetJet1EnergyRegression(BDTInfo reg1);
+    void                            SetJet2EnergyRegression(BDTInfo reg2);
     void                            ConfigureOutputTree();
 
     //General Physics Information
@@ -104,6 +111,7 @@ public :
     void            SetBranches();
     void            PrintBranches();
     void            GetEarlyEntries(Long64_t entry);
+    void            PrintBDTInfoValues(BDTInfo bdt);
     
     void            Loop();
     //virtual void     WriteBDTs(std::string indirname, std::string infilename, std::string outdirname, std::string outfilename, std::string cutstring);
@@ -122,7 +130,7 @@ public :
     // general use functions
     double          EvalDeltaR(double eta0, double phi0, double eta1, double phi1); 
     double          EvalDeltaPhi(double phi0, double phi1); 
-    void            SetupBDT();
+    void            SetupBDT(BDTInfo bdtInfo);
 
 };
 

--- a/HelperClasses/BDTInfo.h
+++ b/HelperClasses/BDTInfo.h
@@ -4,26 +4,34 @@
 #include <map>
 #include <string>
 
+#include "TMVA/Reader.h"
+
 class BDTInfo{
 
 public:
-  std::map<char*,float*> inputs;
-  std::map<char*,float*> secInputs;
-  std::string method;
+  std::string bdtname;
+  std::vector<std::string> inputNames;
+  std::vector<std::string> localVarNames;
+  std::vector<std::string> inputSpectatorNames;
+  std::vector<std::string> localSpectatorVarNames;
+  //std::string method;
   std::string xmlFile;
-  std::string outputBranch;
+  TMVA::Reader *reader;
 
-  BDTInfo(std::map<char*,float*>, std::map<char*,float*>, char*, char*, char*);
+  BDTInfo(std::string, std::string);
   BDTInfo();
+  void AddVariable(std::string, std::string);
+  void AddSpectatorVariable(std::string, std::string);
 
 };
 
-BDTInfo::BDTInfo(std::map<char*,float*> _inputs, std::map<char*,float*> _secInputs, char* _method, char* _xmlFile, char* _outputBranch) {
-    inputs = _inputs;
-    secInputs = _secInputs;
-    method = _method;
+BDTInfo::BDTInfo(std::string _bdtname, std::string _xmlFile) {
+    bdtname = _bdtname;
+    inputNames = std::vector<std::string>();
+    localVarNames = std::vector<std::string>();
+    //method = _method;
     xmlFile = _xmlFile;
-    outputBranch = _outputBranch;
+    reader = new TMVA::Reader( "!Color:Silent" );    
 
    /* map<char*,float*> floatMap;
   floatMap["H.massCorr"] = &H.massCorr;
@@ -48,12 +56,17 @@ BDTInfo::BDTInfo(std::map<char*,float*> _inputs, std::map<char*,float*> _secInpu
 }
 
 BDTInfo::BDTInfo() {
-    inputs = std::map<char*,float*>();
-    secInputs = std::map<char*,float*>();
-    method = "";
-    xmlFile = "";
-    outputBranch = "";
+    BDTInfo("", "");
 }
 
+void BDTInfo::AddVariable(std::string varName, std::string localVarName) {
+    inputNames.push_back(varName);
+    localVarNames.push_back(localVarName);
+}
+
+void BDTInfo::AddSpectatorVariable(std::string varName, std::string localVarName) {
+    inputSpectatorNames.push_back(varName);
+    localSpectatorVarNames.push_back(localVarName);
+}
 
 #endif

--- a/JetEnergyRegression/weights/Wln_noMET.xml
+++ b/JetEnergyRegression/weights/Wln_noMET.xml
@@ -1,0 +1,4603 @@
+<?xml version="1.0"?>
+<MethodSetup Method="BDT::BDTG">
+  <GeneralInfo>
+    <Info name="TMVA Release" value="4.2.0 [262656]"/>
+    <Info name="ROOT Release" value="5.34/18 [336402]"/>
+    <Info name="Creator" value="cvernier"/>
+    <Info name="Date" value="Mon Jan 19 18:40:29 2015"/>
+    <Info name="Host" value="Linux cmsdev04.cern.ch 2.6.32-431.11.2.el6.x86_64 #1 SMP Wed Mar 26 09:39:43 CET 2014 x86_64 x86_64 x86_64 GNU/Linux"/>
+    <Info name="Dir" value="/afs/cern.ch/work/c/cvernier/testRegression/CMSSW_7_1_4/src/RegressionPhys14"/>
+    <Info name="Training events" value="40066"/>
+    <Info name="TrainingTime" value="1.19417849e+01"/>
+    <Info name="AnalysisType" value="Regression"/>
+  </GeneralInfo>
+  <Options>
+    <Option name="V" modified="Yes">False</Option>
+    <Option name="VerbosityLevel" modified="No">Default</Option>
+    <Option name="VarTransform" modified="No">None</Option>
+    <Option name="H" modified="Yes">False</Option>
+    <Option name="CreateMVAPdfs" modified="No">False</Option>
+    <Option name="IgnoreNegWeightsInTraining" modified="No">False</Option>
+    <Option name="NTrees" modified="Yes">200</Option>
+    <Option name="MaxDepth" modified="Yes">3</Option>
+    <Option name="MinNodeSize" modified="No">0.2%</Option>
+    <Option name="nCuts" modified="Yes">20</Option>
+    <Option name="BoostType" modified="Yes">Grad</Option>
+    <Option name="AdaBoostR2Loss" modified="No">quadratic</Option>
+    <Option name="UseBaggedBoost" modified="No">True</Option>
+    <Option name="Shrinkage" modified="Yes">1.000000e-01</Option>
+    <Option name="AdaBoostBeta" modified="No">5.000000e-01</Option>
+    <Option name="UseRandomisedTrees" modified="No">False</Option>
+    <Option name="UseNvars" modified="No">4</Option>
+    <Option name="UsePoissonNvars" modified="No">True</Option>
+    <Option name="BaggedSampleFraction" modified="No">5.000000e-01</Option>
+    <Option name="UseYesNoLeaf" modified="No">False</Option>
+    <Option name="NegWeightTreatment" modified="No">ignorenegweightsintraining</Option>
+    <Option name="Css" modified="No">1.000000e+00</Option>
+    <Option name="Cts_sb" modified="No">1.000000e+00</Option>
+    <Option name="Ctb_ss" modified="No">1.000000e+00</Option>
+    <Option name="Cbb" modified="No">1.000000e+00</Option>
+    <Option name="NodePurityLimit" modified="No">5.000000e-01</Option>
+    <Option name="SeparationType" modified="No">regressionvariance</Option>
+    <Option name="DoBoostMonitor" modified="No">False</Option>
+    <Option name="UseFisherCuts" modified="No">False</Option>
+    <Option name="MinLinCorrForFisher" modified="No">8.000000e-01</Option>
+    <Option name="UseExclusiveVars" modified="No">False</Option>
+    <Option name="DoPreselection" modified="No">False</Option>
+    <Option name="SigToBkgFraction" modified="No">1.000000e+00</Option>
+    <Option name="PruneMethod" modified="Yes">costcomplexity</Option>
+    <Option name="PruneStrength" modified="Yes">3.000000e+01</Option>
+    <Option name="PruningValFraction" modified="No">5.000000e-01</Option>
+    <Option name="nEventsMin" modified="No">0</Option>
+    <Option name="UseBaggedGrad" modified="Yes">True</Option>
+    <Option name="GradBaggingFraction" modified="Yes">5.000000e-01</Option>
+    <Option name="UseNTrainEvents" modified="No">0</Option>
+    <Option name="NNodesMax" modified="No">0</Option>
+  </Options>
+  <Variables NVar="18">
+    <Variable VarIndex="0" Expression="Jet_pt" Label="Jet_pt" Title="Jet_pt" Unit="units" Internal="Jet_pt" Type="F" Min="2.50032806e+01" Max="9.82066284e+02"/>
+    <Variable VarIndex="1" Expression="Jet_rawPt" Label="Jet_rawPt" Title="Jet_rawPt" Unit="units" Internal="Jet_rawPt" Type="F" Min="2.23941250e+01" Max="9.50544312e+02"/>
+    <Variable VarIndex="2" Expression="rho" Label="rho" Title="rho" Unit="units" Internal="rho" Type="F" Min="4.65321350e+00" Max="4.79797859e+01"/>
+    <Variable VarIndex="3" Expression="Jet_eta" Label="Jet_eta" Title="Jet_eta" Unit="units" Internal="Jet_eta" Type="F" Min="-2.39998913e+00" Max="2.39992356e+00"/>
+    <Variable VarIndex="4" Expression="Jet_mt" Label="Jet_mt" Title="Jet_mt" Unit="units" Internal="Jet_mt" Type="F" Min="2.52719975e+01" Max="9.88879761e+02"/>
+    <Variable VarIndex="5" Expression="Jet_leadTrackPt" Label="Jet_leadTrackPt" Title="Jet_leadTrackPt  " Unit="units" Internal="Jet_leadTrackPt" Type="F" Min="5.40527344e-01" Max="2.47125000e+02"/>
+    <Variable VarIndex="6" Expression="Jet_leptonPtRel" Label="Jet_leptonPtRel" Title="Jet_leptonPtRel" Unit="units" Internal="Jet_leptonPtRel" Type="F" Min="-9.90000000e+01" Max="2.05813847e+01"/>
+    <Variable VarIndex="7" Expression="Jet_leptonPt" Label="Jet_leptonPt" Title="Jet_leptonPt" Unit="units" Internal="Jet_leptonPt" Type="F" Min="-9.90000000e+01" Max="3.16615479e+02"/>
+    <Variable VarIndex="8" Expression="Jet_leptonDeltaR" Label="Jet_leptonDeltaR" Title="Jet_leptonDeltaR" Unit="units" Internal="Jet_leptonDeltaR" Type="F" Min="-9.90000000e+01" Max="3.89645517e-01"/>
+    <Variable VarIndex="9" Expression="Jet_chEmEF" Label="Jet_chEmEF" Title="Jet_chEmEF " Unit="units" Internal="Jet_chEmEF" Type="F" Min="0.00000000e+00" Max="9.62788343e-01"/>
+    <Variable VarIndex="10" Expression="Jet_chHEF" Label="Jet_chHEF" Title="Jet_chHEF" Unit="units" Internal="Jet_chHEF" Type="F" Min="8.40473548e-03" Max="1.26967120e+00"/>
+    <Variable VarIndex="11" Expression="Jet_neHEF" Label="Jet_neHEF" Title="Jet_neHEF" Unit="units" Internal="Jet_neHEF" Type="F" Min="0.00000000e+00" Max="8.25332046e-01"/>
+    <Variable VarIndex="12" Expression="Jet_neEmEF" Label="Jet_neEmEF" Title="Jet_neEmEF" Unit="units" Internal="Jet_neEmEF" Type="F" Min="0.00000000e+00" Max="9.71923828e-01"/>
+    <Variable VarIndex="13" Expression="Jet_chMult" Label="Jet_chMult" Title="Jet_chMult" Unit="units" Internal="Jet_chMult" Type="F" Min="2.00000000e+00" Max="6.10000000e+01"/>
+    <Variable VarIndex="14" Expression="Jet_puId" Label="Jet_puId" Title="Jet_puId" Unit="units" Internal="Jet_puId" Type="F" Min="0.00000000e+00" Max="1.00000000e+00"/>
+    <Variable VarIndex="15" Expression="Jet_vtxMass" Label="Jet_vtxMass" Title="Jet_vtxMass" Unit="units" Internal="Jet_vtxMass" Type="F" Min="0.00000000e+00" Max="6.37491179e+00"/>
+    <Variable VarIndex="16" Expression="Jet_vtx3dL" Label="Jet_vtx3dL" Title="Jet_vtx3dL" Unit="units" Internal="Jet_vtx3dL" Type="F" Min="0.00000000e+00" Max="1.30689716e+01"/>
+    <Variable VarIndex="17" Expression="Jet_vtxNtrk" Label="Jet_vtxNtrk" Title="Jet_vtxNtrk" Unit="units" Internal="Jet_vtxNtrk" Type="I" Min="0.00000000e+00" Max="1.00000000e+01"/>
+  </Variables>
+  <Spectators NSpec="0"/>
+  <Classes NClass="1">
+    <Class Name="Regression" Index="0"/>
+  </Classes>
+  <Targets NTrgt="1">
+    <Target TargetIndex="0" Expression="Jet_mcPt" Label="Jet_mcPt" Title="Jet_mcPt" Unit="" Internal="Jet_mcPt" Type="F" Min="1.00026970e+01" Max="1.10688586e+03"/>
+  </Targets>
+  <Transformations NTransformations="0"/>
+  <MVAPdfs/>
+  <Weights NTrees="200" AnalysisType="1">
+    <BinaryTree type="DecisionTree" boostWeight="6.5137039184570312e+01" itree="0">
+      <Node pos="s" depth="0" NCoef="0" IVar="0" Cut="5.8921318054199219e+01" cType="1" res="2.0353176593780518e+00" rms="2.3691768646240234e+01" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="1" Cut="4.6868312835693359e+01" cType="1" res="-1.5545739173889160e+01" rms="1.5336148262023926e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="3.8027072906494141e+01" cType="1" res="-2.2205276489257812e+01" rms="1.1769421577453613e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.8726592063903809e+00" rms="9.6099128723144531e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.7795922756195068e+00" rms="1.2148574829101562e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="5.4907020568847656e+01" cType="1" res="-5.0168242454528809e+00" rms="1.4390016555786133e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.2611718177795410e-01" rms="1.2957299232482910e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.7299630045890808e-02" rms="1.4411841392517090e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="1" Cut="8.5289016723632812e+01" cType="1" res="2.1199312210083008e+01" rms="1.4580176353454590e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="7.0845191955566406e+01" cType="1" res="1.0656702041625977e+01" rms="1.3655654907226562e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.5243573188781738e-01" rms="1.2627503395080566e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7866996526718140e+00" rms="1.1829346656799316e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="0" Cut="1.0133062744140625e+02" cType="1" res="3.1216398239135742e+01" rms="5.6068363189697266e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.4805128574371338e+00" rms="8.0651693344116211e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.8842053413391113e+00" rms="2.4703404903411865e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="1">
+      <Node pos="s" depth="0" NCoef="0" IVar="1" Cut="9.7570159912109375e+01" cType="1" res="4.8429275512695312e+01" rms="5.8979736328125000e+01" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="1" Cut="6.1765819549560547e+01" cType="1" res="3.4945369720458984e+01" rms="3.8734088897705078e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="4.4888153076171875e+01" cType="1" res="2.3944509506225586e+01" rms="3.4371696472167969e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.2255520820617676e+00" rms="3.2827983856201172e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.7203146219253540e-01" rms="3.4197948455810547e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="7.7105575561523438e+01" cType="1" res="5.5480434417724609e+01" rms="3.8053260803222656e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.5786944627761841e-01" rms="3.6417236328125000e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.4666588306427002e+00" rms="3.8548694610595703e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="4" Cut="2.6964031982421875e+02" cType="1" res="1.0978215789794922e+02" rms="8.8817192077636719e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="1.3697650146484375e+02" cType="1" res="1.0144489288330078e+02" rms="6.6493980407714844e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.0519256591796875e+00" rms="4.9968761444091797e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1146794319152832e+01" rms="8.3087577819824219e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="4.1191506958007812e+02" cType="1" res="2.5681732177734375e+02" rms="2.1491325378417969e+02" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.5630102157592773e+01" rms="1.5733610534667969e+02" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.0489524841308594e+01" rms="3.1407086181640625e+02" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="2">
+      <Node pos="s" depth="0" NCoef="0" IVar="0" Cut="6.4712631225585938e+01" cType="1" res="2.9864320755004883e+01" rms="5.1429367065429688e+01" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="1" Cut="5.0673542022705078e+01" cType="1" res="1.1734805107116699e+01" rms="3.4240085601806641e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="4.0548931121826172e+01" cType="1" res="4.6265096664428711e+00" rms="3.1929630279541016e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.2247791290283203e+00" rms="3.0409839630126953e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.2418255805969238e+00" rms="3.2754787445068359e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="6.2178936004638672e+01" cType="1" res="2.4578969955444336e+01" rms="3.4530532836914062e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.6728290319442749e-01" rms="3.4146770477294922e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.7210844755172729e-01" rms="3.4899871826171875e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="1" Cut="1.3122447204589844e+02" cType="1" res="5.5545989990234375e+01" rms="6.0048870086669922e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="9.0283699035644531e+01" cType="1" res="4.6567886352539062e+01" rms="4.1523563385009766e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3472083806991577e+00" rms="3.6221912384033203e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.8582818508148193e+00" rms="4.5194431304931641e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="4" Cut="2.3229312133789062e+02" cType="1" res="9.2497512817382812e+01" rms="9.8250282287597656e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.8433256149291992e+00" rms="7.3016998291015625e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.0402742385864258e+01" rms="1.5907482910156250e+02" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="3">
+      <Node pos="s" depth="0" NCoef="0" IVar="1" Cut="6.6591751098632812e+01" cType="1" res="1.8391633987426758e+01" rms="4.3802803039550781e+01" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="1" Cut="4.9753513336181641e+01" cType="1" res="3.2606234550476074e+00" rms="2.9786659240722656e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="3.4116439819335938e+01" cType="1" res="-2.8806753158569336e+00" rms="2.7585493087768555e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.3709197044372559e+00" rms="2.4532606124877930e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.3423304557800293e+00" rms="2.8179029464721680e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="5.9378391265869141e+01" cType="1" res="1.3276398658752441e+01" rms="3.0518470764160156e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.6412494778633118e-01" rms="2.9402135848999023e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.8372724950313568e-01" rms="3.1782056808471680e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="1" Cut="1.0869468688964844e+02" cType="1" res="4.0439147949218750e+01" rms="5.1008937835693359e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="8.0630317687988281e+01" cType="1" res="3.1467548370361328e+01" rms="3.4070972442626953e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.7296410799026489e-01" rms="3.1281303405761719e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.4088006019592285e+00" rms="3.5189903259277344e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="5" Cut="8.9195175170898438e+01" cType="1" res="5.9141899108886719e+01" rms="7.1333663940429688e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.4326605796813965e+00" rms="6.1255668640136719e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7228664398193359e+01" rms="2.1127468872070312e+02" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="4">
+      <Node pos="s" depth="0" NCoef="0" IVar="0" Cut="6.3088836669921875e+01" cType="1" res="1.2009669303894043e+01" rms="3.6527404785156250e+01" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="1" Cut="4.7364166259765625e+01" cType="1" res="-1.7874798774719238e+00" rms="2.5265027999877930e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="3.3090148925781250e+01" cType="1" res="-7.7671103477478027e+00" rms="2.2905849456787109e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.2440097332000732e+00" rms="1.8830797195434570e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.3154656887054443e+00" rms="2.3631559371948242e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="5.6525104522705078e+01" cType="1" res="6.4948110580444336e+00" rms="2.6030874252319336e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.6345772743225098e-01" rms="2.5040653228759766e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.6203428804874420e-01" rms="2.6531646728515625e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="1" Cut="9.3337768554687500e+01" cType="1" res="3.0204469680786133e+01" rms="4.0864555358886719e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="7.6777229309082031e+01" cType="1" res="1.9967132568359375e+01" rms="2.7693454742431641e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.5678600072860718e-01" rms="2.5825679779052734e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.6222929954528809e+00" rms="2.8453788757324219e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="0" Cut="1.5603202819824219e+02" cType="1" res="4.1552543640136719e+01" rms="4.9253589630126953e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.6413874626159668e+00" rms="3.7776809692382812e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1341373443603516e+01" rms="7.4007453918457031e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="5">
+      <Node pos="s" depth="0" NCoef="0" IVar="1" Cut="6.8215476989746094e+01" cType="1" res="8.2948684692382812e+00" rms="3.4648078918457031e+01" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="1" Cut="4.3004508972167969e+01" cType="1" res="-3.7501003742218018e+00" rms="2.1244245529174805e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="3.5801872253417969e+01" cType="1" res="-1.1225304603576660e+01" rms="1.8775325775146484e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.8942445516586304e+00" rms="1.7267528533935547e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.2177659273147583e+00" rms="1.9797964096069336e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="5.2609687805175781e+01" cType="1" res="1.6203434467315674e+00" rms="2.1291223526000977e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.5034493207931519e-01" rms="2.0748928070068359e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.7064753472805023e-02" rms="2.1031250000000000e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="0" Cut="3.2228002929687500e+02" cType="1" res="2.7032335281372070e+01" rms="4.2298164367675781e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="1.0366075897216797e+02" cType="1" res="2.5925199508666992e+01" rms="3.4681781768798828e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3076322078704834e+00" rms="2.4481079101562500e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.7806262969970703e+00" rms="4.4345077514648438e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="2" Cut="2.0226551055908203e+01" cType="1" res="1.3095635986328125e+02" rms="2.1426428222656250e+02" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.9590841293334961e+01" rms="2.5253773498535156e+02" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.7617740631103516e+01" rms="1.5901811218261719e+02" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="6">
+      <Node pos="s" depth="0" NCoef="0" IVar="1" Cut="6.7655593872070312e+01" cType="1" res="5.2338728904724121e+00" rms="2.7432100296020508e+01" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="1" Cut="4.4531345367431641e+01" cType="1" res="-5.1298317909240723e+00" rms="1.8223018646240234e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="3.6523368835449219e+01" cType="1" res="-1.0968150138854980e+01" rms="1.6287496566772461e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.6675398349761963e+00" rms="1.5144590377807617e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.0473763942718506e+00" rms="1.6970573425292969e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="5.5542301177978516e+01" cType="1" res="1.9424536824226379e-01" rms="1.8263666152954102e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.1269330978393555e-01" rms="1.7777601242065430e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.2610933780670166e-02" rms="1.8158563613891602e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="1" Cut="1.0969857025146484e+02" cType="1" res="2.0832153320312500e+01" rms="3.1310689926147461e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="8.3671577453613281e+01" cType="1" res="1.5596982002258301e+01" rms="2.2004114151000977e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.8092012405395508e-01" rms="1.9504848480224609e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7864897251129150e+00" rms="2.3631912231445312e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="4" Cut="2.7200973510742188e+02" cType="1" res="3.1194734573364258e+01" rms="4.2436653137207031e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.8253278732299805e+00" rms="3.4190555572509766e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.9132307052612305e+01" rms="9.9231971740722656e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="7">
+      <Node pos="s" depth="0" NCoef="0" IVar="1" Cut="5.9982143402099609e+01" cType="1" res="3.6209688186645508e+00" rms="2.2195348739624023e+01" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="1" Cut="4.5659675598144531e+01" cType="1" res="-7.1088318824768066e+00" rms="1.5185854911804199e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="3.5686889648437500e+01" cType="1" res="-1.0734975814819336e+01" rms="1.3704333305358887e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.5539585351943970e+00" rms="1.2382826805114746e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.5533341169357300e-01" rms="1.4169117927551270e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="7" Cut="-9.2359558105468750e+01" cType="1" res="-2.1570284366607666e+00" rms="1.5702956199645996e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.2463477849960327e-01" rms="1.5327562332153320e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.4467441737651825e-02" rms="1.6115051269531250e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="1" Cut="9.5782875061035156e+01" cType="1" res="1.4812875747680664e+01" rms="2.2816568374633789e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="7.5320358276367188e+01" cType="1" res="9.4368591308593750e+00" rms="1.7153207778930664e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.1925559043884277e-01" rms="1.6287982940673828e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2246941328048706e+00" rms="1.7060651779174805e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="2.6626040649414062e+02" cType="1" res="2.3361322402954102e+01" rms="2.7595384597778320e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.3720321655273438e+00" rms="2.2128168106079102e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7645881652832031e+01" rms="7.7130432128906250e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="8">
+      <Node pos="s" depth="0" NCoef="0" IVar="1" Cut="5.9982143402099609e+01" cType="1" res="2.5544290542602539e+00" rms="1.9399744033813477e+01" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="1" Cut="4.2072551727294922e+01" cType="1" res="-7.1246609687805176e+00" rms="1.3370740890502930e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="3.0826566696166992e+01" cType="1" res="-1.1111750602722168e+01" rms="1.2228034019470215e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.6977890729904175e+00" rms="9.4415826797485352e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.0609314441680908e+00" rms="1.2603035926818848e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="5.2296207427978516e+01" cType="1" res="-3.6284942626953125e+00" rms="1.3351560592651367e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.4864277839660645e-01" rms="1.2817893028259277e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.7375150322914124e-01" rms="1.3579351425170898e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="0" Cut="8.2085655212402344e+01" cType="1" res="1.2567893028259277e+01" rms="1.9584638595581055e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="7.3597152709960938e+01" cType="1" res="6.1244130134582520e+00" rms="1.5970369338989258e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.9009456038475037e-01" rms="1.4887047767639160e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.1370359659194946e-01" rms="1.7101234436035156e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="1.1256969451904297e+02" cType="1" res="1.8005260467529297e+01" rms="2.0673593521118164e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3221137523651123e+00" rms="1.6178937911987305e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.3723392486572266e+00" rms="2.4210708618164062e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="9">
+      <Node pos="s" depth="0" NCoef="0" IVar="1" Cut="6.8100639343261719e+01" cType="1" res="1.7396515607833862e+00" rms="1.7008031845092773e+01" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="1" Cut="4.9188209533691406e+01" cType="1" res="-5.4405293464660645e+00" rms="1.2739066123962402e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="4.1979713439941406e+01" cType="1" res="-8.9648904800415039e+00" rms="1.1226701736450195e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.1102725267410278e+00" rms="1.0620041847229004e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.9752082824707031e-01" rms="1.1637613296508789e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="13" Cut="1.2333333015441895e+01" cType="1" res="-3.5703307390213013e-01" rms="1.3069243431091309e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1572643369436264e-01" rms="1.4238262176513672e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.8334721922874451e-01" rms="1.1990271568298340e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="1" Cut="1.1012648010253906e+02" cType="1" res="1.2866211891174316e+01" rms="1.6803791046142578e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="8.6108245849609375e+01" cType="1" res="9.5346136093139648e+00" rms="1.4464117050170898e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.6143635511398315e-01" rms="1.3833777427673340e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3143280744552612e+00" rms="1.4496475219726562e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="4" Cut="2.3134661865234375e+02" cType="1" res="1.9514287948608398e+01" rms="1.9026380538940430e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.4453222751617432e+00" rms="1.3497997283935547e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2482872009277344e+01" rms="4.0904541015625000e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="10">
+      <Node pos="s" depth="0" NCoef="0" IVar="1" Cut="6.1491031646728516e+01" cType="1" res="1.2473051548004150e+00" rms="1.4943608283996582e+01" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="1" Cut="4.1839492797851562e+01" cType="1" res="-5.9878907203674316e+00" rms="1.1633550643920898e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="3.5033302307128906e+01" cType="1" res="-9.6336517333984375e+00" rms="1.0234327316284180e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.2143660783767700e+00" rms="8.9765863418579102e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.5954920053482056e-01" rms="1.0917330741882324e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="7" Cut="-9.2264335632324219e+01" cType="1" res="-3.0486385822296143e+00" rms="1.1859719276428223e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.0962996482849121e-01" rms="1.1707608222961426e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.2142333909869194e-02" rms="1.1649264335632324e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="0" Cut="8.8468040466308594e+01" cType="1" res="9.4557275772094727e+00" rms="1.4012456893920898e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="7.4535240173339844e+01" cType="1" res="4.9716138839721680e+00" rms="1.2071978569030762e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7618246376514435e-01" rms="1.1735565185546875e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.9595416784286499e-01" rms="1.1787095069885254e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="1.1701970672607422e+02" cType="1" res="1.4368521690368652e+01" rms="1.4340120315551758e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0908375978469849e+00" rms="1.2102722167968750e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.8805384635925293e+00" rms="1.5461382865905762e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="11">
+      <Node pos="s" depth="0" NCoef="0" IVar="1" Cut="6.1045982360839844e+01" cType="1" res="1.0683584213256836e+00" rms="1.3546583175659180e+01" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="1" Cut="3.7809772491455078e+01" cType="1" res="-5.4112520217895508e+00" rms="1.1188340187072754e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="3.0319110870361328e+01" cType="1" res="-9.5227088928222656e+00" rms="9.5888748168945312e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.3788037300109863e+00" rms="7.1516785621643066e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.6840790510177612e-01" rms="1.0029315948486328e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="6" Cut="-9.4107208251953125e+01" cType="1" res="-3.4688913822174072e+00" rms="1.1363103866577148e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.1045197248458862e-01" rms="1.0996179580688477e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.2475964426994324e-02" rms="1.1752714157104492e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="1" Cut="9.6796058654785156e+01" cType="1" res="8.2060060501098633e+00" rms="1.2270674705505371e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="7.4664611816406250e+01" cType="1" res="4.7622771263122559e+00" rms="1.1505213737487793e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.8059472739696503e-01" rms="1.1541331291198730e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.1958625316619873e-01" rms="1.0918533325195312e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="1.3084475708007812e+02" cType="1" res="1.3577216148376465e+01" rms="1.1472075462341309e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2417764663696289e+00" rms="1.1043187141418457e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.0174670219421387e+00" rms="1.0984375000000000e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="12">
+      <Node pos="s" depth="0" NCoef="0" IVar="1" Cut="6.6591751098632812e+01" cType="1" res="8.6397159099578857e-01" rms="1.2833250045776367e+01" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="1" Cut="4.1335494995117188e+01" cType="1" res="-4.2441492080688477e+00" rms="1.0748705863952637e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="3.0511310577392578e+01" cType="1" res="-7.9799046516418457e+00" rms="9.6666116714477539e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.1968817710876465e+00" rms="7.1733455657958984e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.2753578424453735e-01" rms="9.9840002059936523e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="5.3363758087158203e+01" cType="1" res="-1.9211641550064087e+00" rms="1.0732997894287109e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.1111454367637634e-01" rms="1.0283785820007324e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.7485516145825386e-02" rms="1.0868537902832031e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="4" Cut="1.3392202758789062e+02" cType="1" res="8.2452001571655273e+00" rms="1.1980747222900391e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="8.3126235961914062e+01" cType="1" res="6.4355149269104004e+00" rms="1.1487339973449707e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.1447476148605347e-01" rms="9.9129705429077148e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.6263444423675537e-01" rms="1.2060718536376953e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="1.5992727661132812e+02" cType="1" res="1.5593144416809082e+01" rms="1.1102458953857422e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.0570952892303467e+00" rms="8.0633316040039062e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.2528171539306641e+00" rms="1.2960125923156738e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="13">
+      <Node pos="s" depth="0" NCoef="0" IVar="1" Cut="5.9982143402099609e+01" cType="1" res="8.1223165988922119e-01" rms="1.1773644447326660e+01" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="1" Cut="4.3872444152832031e+01" cType="1" res="-4.7313532829284668e+00" rms="9.9914760589599609e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="3.3642189025878906e+01" cType="1" res="-6.8973217010498047e+00" rms="9.3563003540039062e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.3582743406295776e-01" rms="8.0790376663208008e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.8496880531311035e-01" rms="9.7419319152832031e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="13" Cut="1.5809523582458496e+01" cType="1" res="-2.2931020259857178e+00" rms="1.0121139526367188e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.4229856431484222e-01" rms="1.0148284912109375e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.1751351356506348e-01" rms="9.6783285140991211e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="1" Cut="9.5782875061035156e+01" cType="1" res="6.5586929321289062e+00" rms="1.0674715995788574e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="7.1905227661132812e+01" cType="1" res="3.4494259357452393e+00" rms="1.0362536430358887e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.5253714323043823e-02" rms="1.0464017868041992e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.5683451890945435e-01" rms="9.8281459808349609e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="1.2989176940917969e+02" cType="1" res="1.1210659027099609e+01" rms="9.3632507324218750e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0515843629837036e+00" rms="1.0829364776611328e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.8144874572753906e+00" rms="5.5000910758972168e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="14">
+      <Node pos="s" depth="0" NCoef="0" IVar="1" Cut="5.8885269165039062e+01" cType="1" res="4.4352605938911438e-01" rms="1.1257490158081055e+01" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="1" Cut="3.6295288085937500e+01" cType="1" res="-4.5266866683959961e+00" rms="9.6715450286865234e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="2.9013101577758789e+01" cType="1" res="-7.4727296829223633e+00" rms="8.9698123931884766e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.1904764175415039e+00" rms="5.5120625495910645e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.8489885330200195e-01" rms="9.3437585830688477e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="13" Cut="1.2666666984558105e+01" cType="1" res="-3.3787982463836670e+00" rms="9.6920766830444336e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.8388004601001740e-01" rms="9.8735113143920898e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.1985776424407959e-01" rms="9.3093128204345703e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="1" Cut="1.2839306640625000e+02" cType="1" res="5.3855805397033691e+00" rms="1.0523703575134277e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="7.5429450988769531e+01" cType="1" res="3.8312599658966064e+00" rms="1.0347462654113770e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.1930821537971497e-02" rms="1.0036561012268066e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.4852535724639893e-01" rms="1.0089882850646973e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="1.5984678649902344e+02" cType="1" res="1.3251753807067871e+01" rms="7.4337573051452637e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.5820860862731934e+00" rms="7.7859306335449219e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.5810847282409668e+00" rms="6.4281797409057617e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="15">
+      <Node pos="s" depth="0" NCoef="0" IVar="1" Cut="6.6591751098632812e+01" cType="1" res="4.8868471384048462e-01" rms="1.0849502563476562e+01" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="1" Cut="4.7647235870361328e+01" cType="1" res="-3.2937450408935547e+00" rms="9.5070753097534180e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="7" Cut="-9.2621238708496094e+01" cType="1" res="-5.1091947555541992e+00" rms="9.0781106948852539e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.3548332452774048e-01" rms="8.7159271240234375e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.1406255662441254e-01" rms="9.7136783599853516e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="13" Cut="1.4857142448425293e+01" cType="1" res="-9.5726633071899414e-01" rms="9.5364580154418945e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.8773343414068222e-02" rms="9.6147747039794922e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.9121509194374084e-01" rms="9.1945199966430664e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="4" Cut="1.3392202758789062e+02" cType="1" res="6.0236482620239258e+00" rms="1.0301901817321777e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="8.6699775695800781e+01" cType="1" res="4.4624681472778320e+00" rms="9.9324493408203125e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.3206742107868195e-01" rms="9.5686159133911133e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.2316267490386963e-01" rms="9.8547697067260742e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="0" Cut="1.7211721801757812e+02" cType="1" res="1.2427571296691895e+01" rms="9.2620811462402344e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4688385725021362e+00" rms="1.1999974250793457e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.4369125366210938e+00" rms="3.0149559974670410e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="16">
+      <Node pos="s" depth="0" NCoef="0" IVar="1" Cut="5.8236255645751953e+01" cType="1" res="3.3721417188644409e-01" rms="1.0230573654174805e+01" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="1" Cut="4.0125148773193359e+01" cType="1" res="-3.5880777835845947e+00" rms="9.1286163330078125e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="1.5349519252777100e-01" cType="1" res="-5.6192312240600586e+00" rms="8.6483821868896484e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.4138424396514893e-01" rms="8.4654407501220703e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.0736448019742966e-02" rms="9.1324987411499023e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="7" Cut="-9.2359558105468750e+01" cType="1" res="-2.1202507019042969e+00" rms="9.1850500106811523e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.1386205554008484e-01" rms="8.9544544219970703e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7619362100958824e-02" rms="9.4561176300048828e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="1" Cut="1.2409755706787109e+02" cType="1" res="4.1609964370727539e+00" rms="9.7885236740112305e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="8.0182197570800781e+01" cType="1" res="2.6473352909088135e+00" rms="9.6569633483886719e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.1000628173351288e-02" rms="9.5908298492431641e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.3245574235916138e-01" rms="9.3425302505493164e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="0" Cut="1.8231442260742188e+02" cType="1" res="1.0905884742736816e+01" rms="7.1771750450134277e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4219011068344116e+00" rms="8.1751451492309570e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.3830523490905762e+00" rms="2.7144517898559570e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="17">
+      <Node pos="s" depth="0" NCoef="0" IVar="1" Cut="6.8216491699218750e+01" cType="1" res="3.6617076396942139e-01" rms="1.0197344779968262e+01" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="1" Cut="5.1399909973144531e+01" cType="1" res="-2.5459723472595215e+00" rms="9.2589864730834961e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="7" Cut="-9.2843788146972656e+01" cType="1" res="-3.8490431308746338e+00" rms="8.9112586975097656e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.1125633716583252e-01" rms="8.5558032989501953e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.2054306268692017e-01" rms="9.4741611480712891e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="7" Cut="3.4774715900421143e+00" cType="1" res="-2.2040185332298279e-01" rms="9.4109687805175781e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.6195723414421082e-01" rms="9.1298570632934570e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.4454965591430664e-01" rms="9.6201429367065430e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="1" Cut="1.5226400756835938e+02" cType="1" res="5.0060853958129883e+00" rms="9.9012031555175781e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="8.8231491088867188e+01" cType="1" res="3.9631788730621338e+00" rms="9.6667404174804688e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.1800523996353149e-01" rms="9.2749834060668945e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.3596864938735962e-01" rms="9.7174711227416992e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="1.9039091491699219e+02" cType="1" res="1.2187725067138672e+01" rms="8.4000902175903320e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.8858407735824585e+00" rms="7.2803897857666016e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.5983939170837402e+00" rms="8.9856891632080078e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="18">
+      <Node pos="s" depth="0" NCoef="0" IVar="1" Cut="6.7655593872070312e+01" cType="1" res="2.6475331187248230e-01" rms="9.8267259597778320e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="1" Cut="4.2429538726806641e+01" cType="1" res="-2.4470767974853516e+00" rms="9.0396013259887695e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="2.8915840148925781e+01" cType="1" res="-4.3355779647827148e+00" rms="8.5512180328369141e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.0015876293182373e-01" rms="5.8456478118896484e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.1485604643821716e-01" rms="8.6669340133666992e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="7" Cut="7.6426467895507812e+00" cType="1" res="-1.1123163700103760e+00" rms="9.1369657516479492e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.0526592433452606e-01" rms="9.0413541793823242e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.8844658136367798e-01" rms="9.0564537048339844e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="1" Cut="1.5174085998535156e+02" cType="1" res="4.3163628578186035e+00" rms="9.5576457977294922e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="8" Cut="-9.4267906188964844e+01" cType="1" res="3.2024238109588623e+00" rms="9.5065622329711914e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.0966787636280060e-01" rms="9.5059776306152344e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.3452001810073853e-01" rms="9.1644420623779297e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="1.8978761291503906e+02" cType="1" res="1.1827616691589355e+01" rms="5.7558155059814453e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7073676586151123e+00" rms="7.4178042411804199e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.6409063339233398e+00" rms="2.3819193840026855e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="19">
+      <Node pos="s" depth="0" NCoef="0" IVar="1" Cut="5.9883251190185547e+01" cType="1" res="2.0853626728057861e-01" rms="9.6735267639160156e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="1" Cut="3.2284896850585938e+01" cType="1" res="-2.8108291625976562e+00" rms="8.6985473632812500e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="2.8998266220092773e+01" cType="1" res="-5.8256111145019531e+00" rms="7.6578440666198730e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.5775274038314819e-01" rms="6.2034716606140137e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.9963763356208801e-01" rms="8.0401468276977539e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="7" Cut="-9.2427612304687500e+01" cType="1" res="-2.2868790626525879e+00" rms="8.7617893218994141e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.1653767824172974e-01" rms="8.5476770401000977e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.6867063045501709e-02" rms="9.1119146347045898e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="0" Cut="1.5066992187500000e+02" cType="1" res="3.3499982357025146e+00" rms="9.6363811492919922e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="8.6707366943359375e+01" cType="1" res="2.3276991844177246e+00" rms="9.5544023513793945e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.5059426724910736e-02" rms="9.2513227462768555e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.2424782514572144e-01" rms="9.6731910705566406e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="1.7122906494140625e+02" cType="1" res="1.0934376716613770e+01" rms="6.2654056549072266e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1830240488052368e+00" rms="8.0797138214111328e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.4066205024719238e+00" rms="4.0963511466979980e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="20">
+      <Node pos="s" depth="0" NCoef="0" IVar="1" Cut="6.0091438293457031e+01" cType="1" res="3.4583702683448792e-01" rms="9.4467525482177734e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="1" Cut="3.9264553070068359e+01" cType="1" res="-2.2669246196746826e+00" rms="8.6776523590087891e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="13" Cut="1.2285714149475098e+01" cType="1" res="-3.8828999996185303e+00" rms="8.1605777740478516e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.8224244713783264e-01" rms="8.2254552841186523e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.2985128164291382e-01" rms="7.7456688880920410e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="16" Cut="1.0105993747711182e+00" cType="1" res="-1.2807023525238037e+00" rms="8.8345298767089844e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.1627534925937653e-01" rms="8.7788963317871094e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.8866600096225739e-01" rms="8.6373291015625000e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="0" Cut="1.5101097106933594e+02" cType="1" res="3.0851135253906250e+00" rms="9.4443035125732422e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="8.2394920349121094e+01" cType="1" res="2.1914086341857910e+00" rms="9.3497161865234375e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.6389975845813751e-02" rms="9.1411800384521484e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.7182765603065491e-01" rms="9.3541021347045898e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="1.7238952636718750e+02" cType="1" res="9.8640193939208984e+00" rms="7.1180663108825684e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.6525222063064575e-01" rms="8.7000446319580078e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.0161776542663574e+00" rms="5.1854987144470215e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="21">
+      <Node pos="s" depth="0" NCoef="0" IVar="1" Cut="6.7655593872070312e+01" cType="1" res="2.6435735821723938e-01" rms="9.3885641098022461e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="1" Cut="5.2930465698242188e+01" cType="1" res="-1.7617890834808350e+00" rms="8.7034177780151367e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="16" Cut="9.1880571842193604e-01" cType="1" res="-2.6468367576599121e+00" rms="8.4160356521606445e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.6086481809616089e-01" rms="8.2515773773193359e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.9582719802856445e-02" rms="8.6641893386840820e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="2.0347763597965240e-01" cType="1" res="2.6895618438720703e-01" rms="9.0064849853515625e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.5927972048521042e-02" rms="8.9836435317993164e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.1604094505310059e-01" rms="8.2301931381225586e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="1" Cut="1.5174085998535156e+02" cType="1" res="3.2799239158630371e+00" rms="9.5598278045654297e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="7" Cut="-8.9328697204589844e+01" cType="1" res="2.3183524608612061e+00" rms="9.5068035125732422e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.5555088222026825e-01" rms="9.3360109329223633e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.3170722723007202e-01" rms="9.6812915802001953e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="1.8978973388671875e+02" cType="1" res="9.7670803070068359e+00" rms="7.0632739067077637e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0501948595046997e+00" rms="8.6610479354858398e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.4841713905334473e+00" rms="3.1636774539947510e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="22">
+      <Node pos="s" depth="0" NCoef="0" IVar="1" Cut="9.6522270202636719e+01" cType="1" res="1.7942544817924500e-01" rms="9.1558046340942383e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="1" Cut="5.1413349151611328e+01" cType="1" res="-8.7906926870346069e-01" rms="8.7816152572631836e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="13" Cut="1.6142856597900391e+01" cType="1" res="-2.5007076263427734e+00" rms="8.2680521011352539e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.2117248177528381e-01" rms="8.2513179779052734e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.1778706312179565e-01" rms="7.8330121040344238e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="7" Cut="-9.1215354919433594e+01" cType="1" res="6.3852417469024658e-01" rms="8.9747972488403320e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.9342503994703293e-02" rms="8.8304891586303711e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.8654980659484863e-01" rms="9.0870923995971680e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="1" Cut="1.9545375061035156e+02" cType="1" res="4.9040112495422363e+00" rms="9.2986593246459961e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="1.2479492187500000e+02" cType="1" res="3.8679971694946289e+00" rms="9.3942861557006836e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.1883239746093750e-01" rms="9.4706258773803711e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.3782732486724854e-01" rms="8.9980878829956055e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="4" Cut="2.2275085449218750e+02" cType="1" res="1.1998261451721191e+01" rms="4.0677351951599121e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.6477954387664795e+00" rms="5.6734027862548828e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.8813295364379883e+00" rms="3.0665216445922852e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="23">
+      <Node pos="s" depth="0" NCoef="0" IVar="1" Cut="1.3515817260742188e+02" cType="1" res="2.2912782430648804e-01" rms="9.0411539077758789e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="1" Cut="5.4608871459960938e+01" cType="1" res="-2.9469180107116699e-01" rms="8.8591833114624023e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="13" Cut="1.3571428298950195e+01" cType="1" res="-1.9223629236221313e+00" rms="8.3167963027954102e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.2093547731637955e-01" rms="8.2768783569335938e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.9224275946617126e-01" rms="8.2008829116821289e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="2.2923532128334045e-01" cType="1" res="1.1761013269424438e+00" rms="9.0744724273681641e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.9752720892429352e-02" rms="9.0497179031372070e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.8841552734375000e-01" rms="8.6647157669067383e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="1" Cut="1.9961952209472656e+02" cType="1" res="7.1779460906982422e+00" rms="8.5455980300903320e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="1.7813485717773438e+02" cType="1" res="4.9744749069213867e+00" rms="9.2234163284301758e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.6466659307479858e-01" rms="9.2981309890747070e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.5380506515502930e+00" rms="8.5383758544921875e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="5" Cut="9.8148254394531250e+01" cType="1" res="1.2102753639221191e+01" rms="3.3170580863952637e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.0774102210998535e+00" rms="2.6218786239624023e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.1003079414367676e+00" rms="6.3658666610717773e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="24">
+      <Node pos="s" depth="0" NCoef="0" IVar="1" Cut="1.2762402343750000e+02" cType="1" res="2.0716215670108795e-01" rms="9.0035848617553711e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="1" Cut="5.3531776428222656e+01" cType="1" res="-3.7731185555458069e-01" rms="8.8073577880859375e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="16" Cut="9.1212534904479980e-01" cType="1" res="-1.8820097446441650e+00" rms="8.2882938385009766e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.7637484669685364e-01" rms="8.1973505020141602e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0567329823970795e-01" rms="8.2580547332763672e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="7" Cut="7.3842906951904297e+00" cType="1" res="9.5750838518142700e-01" rms="9.0361061096191406e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4347184449434280e-02" rms="8.9424905776977539e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.8652479648590088e-01" rms="9.0661401748657227e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="4" Cut="2.1812409973144531e+02" cType="1" res="6.4633388519287109e+00" rms="8.6993284225463867e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="15" Cut="2.0812397003173828e+00" cType="1" res="5.1371626853942871e+00" rms="9.0562496185302734e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.7193616628646851e-01" rms="8.7362546920776367e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.1227824687957764e-01" rms="9.7168598175048828e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="3.0910095214843750e+02" cType="1" res="1.1378641128540039e+01" rms="4.6379971504211426e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.0456957817077637e+00" rms="5.3611917495727539e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3367756843566895e+01" rms="4.7272595763206482e-01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="25">
+      <Node pos="s" depth="0" NCoef="0" IVar="1" Cut="9.4960037231445312e+01" cType="1" res="3.0873119831085205e-01" rms="8.9253568649291992e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="1" Cut="4.6581336975097656e+01" cType="1" res="-6.0326325893402100e-01" rms="8.5740261077880859e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="3.1606697082519531e+01" cType="1" res="-2.0239939689636230e+00" rms="8.0762596130371094e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.4050353765487671e-01" rms="7.3085436820983887e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.7135842144489288e-01" rms="8.1752157211303711e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="15" Cut="1.9577145576477051e+00" cType="1" res="2.9262542724609375e-01" rms="8.7558403015136719e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.4668986499309540e-02" rms="8.8054256439208984e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.1491749584674835e-01" rms="8.3123550415039062e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="0" Cut="1.9309471130371094e+02" cType="1" res="4.0307922363281250e+00" rms="9.3544368743896484e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="15" Cut="3.0314815044403076e+00" cType="1" res="3.0378873348236084e+00" rms="9.4020986557006836e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.2084994316101074e-01" rms="9.3305473327636719e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.5592595338821411e-01" rms="9.2785701751708984e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="2.1017828369140625e+02" cType="1" res="9.9025669097900391e+00" rms="6.4738655090332031e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4680998325347900e+00" rms="8.0455245971679688e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.5776133537292480e+00" rms="5.3572797775268555e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="26">
+      <Node pos="s" depth="0" NCoef="0" IVar="1" Cut="5.8885269165039062e+01" cType="1" res="3.8109457492828369e-01" rms="8.8925113677978516e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="1" Cut="3.1081768035888672e+01" cType="1" res="-1.2193764448165894e+00" rms="8.2431030273437500e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="2.6942977905273438e+01" cType="1" res="-4.0239820480346680e+00" rms="7.2879738807678223e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.4512414932250977e-01" rms="4.8234415054321289e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.5247200727462769e-01" rms="7.3832011222839355e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="13" Cut="1.3428571701049805e+01" cType="1" res="-8.6927944421768188e-01" rms="8.2883071899414062e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3345920480787754e-02" rms="8.2409305572509766e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.5884020328521729e-01" rms="8.1883172988891602e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="1" Cut="1.9790100097656250e+02" cType="1" res="1.9410094022750854e+00" rms="9.2191562652587891e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="7.8746330261230469e+01" cType="1" res="1.5463130474090576e+00" rms="9.1583709716796875e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.0972349494695663e-03" rms="8.8227939605712891e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.5000041127204895e-01" rms="9.2822351455688477e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="2.2614643859863281e+02" cType="1" res="9.8169956207275391e+00" rms="6.4918155670166016e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7684890031814575e+00" rms="8.4813966751098633e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.4573562145233154e+00" rms="4.7965955734252930e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="27">
+      <Node pos="s" depth="0" NCoef="0" IVar="1" Cut="1.7365046691894531e+02" cType="1" res="1.3095057010650635e-01" rms="8.8189315795898438e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="1" Cut="7.3468811035156250e+01" cType="1" res="-1.5465280413627625e-01" rms="8.7137012481689453e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="13" Cut="1.3809523582458496e+01" cType="1" res="-9.8237198591232300e-01" rms="8.3327951431274414e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.2213442027568817e-02" rms="8.3469200134277344e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.4635066092014313e-01" rms="8.2059431076049805e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="2" Cut="2.2313032150268555e+01" cType="1" res="1.5879278182983398e+00" rms="9.2260208129882812e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.8417786955833435e-01" rms="9.0583801269531250e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.7205662578344345e-02" rms="9.4862117767333984e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="1" Cut="2.3447363281250000e+02" cType="1" res="8.0382118225097656e+00" rms="8.0044107437133789e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="2" Cut="2.3101892471313477e+01" cType="1" res="6.5337085723876953e+00" rms="8.8797006607055664e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4927691221237183e+00" rms="8.5044202804565430e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.7220964431762695e-01" rms="9.8454408645629883e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="2.9051916503906250e+02" cType="1" res="1.0559116363525391e+01" rms="5.4000463485717773e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.0712411403656006e+00" rms="6.7949113845825195e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.0034370422363281e+00" rms="2.5501246452331543e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="28">
+      <Node pos="s" depth="0" NCoef="0" IVar="1" Cut="2.0008889770507812e+02" cType="1" res="2.8819942474365234e-01" rms="8.7631177902221680e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="1" Cut="8.2286453247070312e+01" cType="1" res="1.0333309322595596e-01" rms="8.6971158981323242e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="13" Cut="1.2666666984558105e+01" cType="1" res="-5.2463245391845703e-01" rms="8.3733701705932617e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.5663438737392426e-02" rms="8.2110710144042969e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.7585571110248566e-01" rms="8.4260311126708984e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="15" Cut="2.3652131557464600e+00" cType="1" res="1.9312272071838379e+00" rms="9.3400964736938477e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.3464017510414124e-01" rms="9.3063755035400391e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.2767568230628967e-01" rms="9.1862859725952148e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="1" Cut="2.3601148986816406e+02" cType="1" res="8.5831651687622070e+00" rms="7.6263394355773926e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="2.3022264099121094e+02" cType="1" res="6.2939667701721191e+00" rms="9.0939331054687500e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.5534294843673706e+00" rms="7.6358208656311035e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1249287128448486e+00" rms="1.0429464340209961e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="13" Cut="2.3142856597900391e+01" cType="1" res="1.0074213981628418e+01" rms="6.0449600219726562e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.9943728446960449e+00" rms="7.0623254776000977e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.2345895767211914e+00" rms="3.0451216697692871e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="29">
+      <Node pos="s" depth="0" NCoef="0" IVar="1" Cut="1.3515817260742188e+02" cType="1" res="2.5462958216667175e-01" rms="8.7326498031616211e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="5" Cut="1.2775809288024902e+01" cType="1" res="-1.1947841942310333e-01" rms="8.5766515731811523e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="12" Cut="3.6548155546188354e-01" cType="1" res="-9.0358030796051025e-01" rms="8.3066406250000000e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.1139018237590790e-01" rms="8.1087589263916016e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.3535907268524170e-02" rms="8.4740152359008789e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="15" Cut="2.2667558193206787e+00" cType="1" res="9.0135514736175537e-01" rms="8.8120040893554688e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7879639565944672e-01" rms="8.8244657516479492e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.9144560396671295e-01" rms="8.4054136276245117e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="1" Cut="1.9967428588867188e+02" cType="1" res="4.7905387878417969e+00" rms="9.3127317428588867e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="-1.9334167242050171e+00" cType="1" res="3.2662925720214844e+00" rms="9.4650802612304688e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.6401165723800659e-01" rms="9.2070770263671875e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.1631256341934204e-01" rms="9.3246345520019531e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="2.8718090820312500e+02" cType="1" res="8.1096639633178711e+00" rms="8.0263166427612305e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4270833730697632e+00" rms="8.6913394927978516e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.8288812637329102e+00" rms="4.9784216880798340e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="30">
+      <Node pos="s" depth="0" NCoef="0" IVar="5" Cut="2.2577404022216797e+01" cType="1" res="1.7584045231342316e-01" rms="8.6516361236572266e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="7" Cut="-8.7730224609375000e+01" cType="1" res="-3.8027361035346985e-01" rms="8.4195756912231445e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="12" Cut="2.8025856614112854e-01" cType="1" res="-8.3896356821060181e-01" rms="8.2572069168090820e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.3512354493141174e-01" rms="7.9596757888793945e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.2539372779428959e-02" rms="8.4002819061279297e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="16" Cut="9.7423082590103149e-01" cType="1" res="1.0455504655838013e+00" rms="8.7532491683959961e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.2441796064376831e-02" rms="8.7001333236694336e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.4190734624862671e-01" rms="8.7066116333007812e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="1" Cut="2.0768238830566406e+02" cType="1" res="2.4658296108245850e+00" rms="9.2003402709960938e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="8" Cut="-9.4267158508300781e+01" cType="1" res="1.9509978294372559e+00" rms="9.1098308563232422e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.7684467434883118e-02" rms="9.1585988998413086e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.4524415731430054e-01" rms="8.8120517730712891e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="4" Cut="3.5992037963867188e+02" cType="1" res="7.8911342620849609e+00" rms="8.3596210479736328e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.6522960662841797e+00" rms="8.8911237716674805e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1994042396545410e+01" rms="7.6968200504779816e-02" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="31">
+      <Node pos="s" depth="0" NCoef="0" IVar="1" Cut="1.3611563110351562e+02" cType="1" res="1.6896711289882660e-01" rms="8.6402788162231445e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="7" Cut="7.3842906951904297e+00" cType="1" res="-1.3545455038547516e-01" rms="8.4963655471801758e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="5.0321720123291016e+01" cType="1" res="-5.7973253726959229e-01" rms="8.3644599914550781e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.8833552300930023e-01" rms="7.8100919723510742e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.0078878626227379e-03" rms="8.6933898925781250e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="5" Cut="9.3220796585083008e+00" cType="1" res="1.5712343454360962e+00" rms="8.7784299850463867e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.6663810610771179e-01" rms="8.2945194244384766e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.5585001707077026e-01" rms="8.7811594009399414e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="1" Cut="2.3266522216796875e+02" cType="1" res="4.1992497444152832e+00" rms="9.4781093597412109e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="-1.9339022636413574e+00" cType="1" res="3.2991080284118652e+00" rms="9.5894327163696289e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.7335532903671265e-01" rms="9.3787679672241211e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.4494001865386963e-01" rms="9.5213394165039062e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="3.4327346801757812e+02" cType="1" res="8.2010440826416016e+00" rms="7.7962279319763184e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3517013788223267e+00" rms="8.6443853378295898e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0839871406555176e+01" rms="1.2873306870460510e-01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="32">
+      <Node pos="s" depth="0" NCoef="0" IVar="5" Cut="1.2246931076049805e+01" cType="1" res="1.5705399215221405e-01" rms="8.6185998916625977e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="12" Cut="5.0481814146041870e-01" cType="1" res="-7.6240396499633789e-01" rms="8.1486864089965820e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="2.1707074642181396e+00" cType="1" res="-1.1999921798706055e+00" rms="8.0636997222900391e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.3445229828357697e-01" rms="8.0345954895019531e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.3913723230361938e-01" rms="7.9410161972045898e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="3" Cut="1.0288499593734741e+00" cType="1" res="1.4337334632873535e+00" rms="8.2177925109863281e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.6795811057090759e-02" rms="8.1341867446899414e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.1489478349685669e-01" rms="8.0511970520019531e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="1" Cut="2.4268147277832031e+02" cType="1" res="1.0635887384414673e+00" rms="8.9662351608276367e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="8" Cut="-9.4269119262695312e+01" cType="1" res="8.8942766189575195e-01" rms="8.9242200851440430e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.9907469395548105e-03" rms="8.8039312362670898e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.1623429059982300e-01" rms="8.9826526641845703e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="3.4708483886718750e+02" cType="1" res="7.9843850135803223e+00" rms="7.8205051422119141e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.5525112152099609e+00" rms="8.4872417449951172e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.6018056869506836e+00" rms="1.2195386737585068e-01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="33">
+      <Node pos="s" depth="0" NCoef="0" IVar="1" Cut="8.6154693603515625e+01" cType="1" res="2.0597673952579498e-01" rms="8.5819730758666992e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="9" Cut="1.6865131258964539e-01" cType="1" res="-3.8829651474952698e-01" rms="8.2317438125610352e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="12" Cut="6.4647996425628662e-01" cType="1" res="-6.4963591098785400e-01" rms="8.1648283004760742e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.0955489426851273e-01" rms="8.1395893096923828e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.1443994045257568e-01" rms="7.7053761482238770e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="14" Cut="4.7619048506021500e-02" cType="1" res="2.1714653968811035e+00" rms="8.4431524276733398e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.8433057069778442e-01" rms="8.0635728836059570e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.3873381316661835e-01" rms="8.4243526458740234e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="1" Cut="2.3037852478027344e+02" cType="1" res="2.0620348453521729e+00" rms="9.3538217544555664e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="-2.1714437007904053e+00" cType="1" res="1.7116551399230957e+00" rms="9.3118000030517578e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.4316003322601318e-01" rms="9.3639612197875977e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.8281158208847046e-01" rms="9.2497911453247070e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="4" Cut="3.5460064697265625e+02" cType="1" res="7.6741929054260254e+00" rms="8.1605701446533203e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4958829879760742e+00" rms="8.8409061431884766e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.7312545776367188e+00" rms="2.5181510448455811e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="34">
+      <Node pos="s" depth="0" NCoef="0" IVar="5" Cut="2.1149112701416016e+01" cType="1" res="1.5622229874134064e-01" rms="8.5581550598144531e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="14" Cut="4.7619048506021500e-02" cType="1" res="-3.0158606171607971e-01" rms="8.3135805130004883e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="2.1717882156372070e+00" cType="1" res="3.0275192260742188e+00" rms="8.6192369461059570e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.2825647592544556e-01" rms="8.3637962341308594e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.4223421812057495e-01" rms="9.3967657089233398e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="3" Cut="2.1709225177764893e+00" cType="1" res="-4.8237636685371399e-01" rms="8.2583284378051758e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.9331838041543961e-02" rms="8.2328271865844727e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.0567200183868408e-01" rms="8.0841493606567383e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="4" Cut="3.3612808227539062e+02" cType="1" res="1.8324903249740601e+00" rms="9.2072553634643555e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="15" Cut="3.0314815044403076e+00" cType="1" res="1.6973434686660767e+00" rms="9.2005338668823242e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.8634133934974670e-01" rms="9.1615009307861328e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.6524877548217773e-01" rms="9.0079765319824219e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.1290435791015625e+00" rms="4.4432120323181152e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="35">
+      <Node pos="s" depth="0" NCoef="0" IVar="1" Cut="1.2630200958251953e+02" cType="1" res="1.3822475075721741e-01" rms="8.5536117553710938e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="16" Cut="1.2446639537811279e+00" cType="1" res="-1.0155791789293289e-01" rms="8.4090976715087891e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="14" Cut="4.7619048506021500e-02" cType="1" res="-4.3926531076431274e-01" rms="8.3524427413940430e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.1256850957870483e-01" rms="8.6018590927124023e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.8921880125999451e-02" rms="8.2999401092529297e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="3" Cut="2.1709244251251221e+00" cType="1" res="1.6296842098236084e+00" rms="8.4852418899536133e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.6661208271980286e-01" rms="8.3845338821411133e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.1517204046249390e-01" rms="8.2997465133666992e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="17" Cut="4.2857141494750977e+00" cType="1" res="2.6578588485717773e+00" rms="9.5901126861572266e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="3.6383099365234375e+02" cType="1" res="3.1538991928100586e+00" rms="9.4514770507812500e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.1500940322875977e-01" rms="9.4767341613769531e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1579265594482422e+01" rms="5.6025190353393555e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="2" Cut="1.8080980300903320e+01" cType="1" res="-9.6488076448440552e-01" rms="9.8147134780883789e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.7282493114471436e-01" rms="9.4100713729858398e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.5596673488616943e-01" rms="9.5522832870483398e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="36">
+      <Node pos="s" depth="0" NCoef="0" IVar="3" Cut="2.1713607311248779e+00" cType="1" res="2.2944642603397369e-01" rms="8.5372934341430664e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="3" Cut="1.0826798677444458e+00" cType="1" res="3.6690312623977661e-01" rms="8.5244989395141602e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="1.1193524169921875e+02" cType="1" res="-2.4780178442597389e-02" rms="8.5313692092895508e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.8624245226383209e-02" rms="8.3152065277099609e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.3682140707969666e-01" rms="9.6431255340576172e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="3.6590671539306641e-01" cType="1" res="1.9098612070083618e+00" rms="8.3198785781860352e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7827023565769196e-01" rms="8.2997407913208008e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.8527300357818604e-01" rms="8.1983900070190430e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="10" Cut="7.5553488731384277e-01" cType="1" res="-3.8192012310028076e+00" rms="7.8972902297973633e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="12" Cut="3.6998826265335083e-01" cType="1" res="-4.4076123237609863e+00" rms="7.6489601135253906e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.2641634941101074e-01" rms="7.0015721321105957e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.1220390796661377e-01" rms="7.9670953750610352e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.8736610412597656e-01" rms="6.6947741508483887e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="37">
+      <Node pos="s" depth="0" NCoef="0" IVar="6" Cut="-9.3420959472656250e+01" cType="1" res="2.1060155332088470e-01" rms="8.5470705032348633e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="12" Cut="3.7025669217109680e-01" cType="1" res="-2.6505017280578613e-01" rms="8.4052667617797852e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="7.3255747556686401e-01" cType="1" res="-7.3450225591659546e-01" rms="8.3241043090820312e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.0927052199840546e-01" rms="8.3496427536010742e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.5404253974556923e-02" rms="8.1683320999145508e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="6.3139343261718750e-01" cType="1" res="7.6477187871932983e-01" rms="8.4901771545410156e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.5374603718519211e-02" rms="8.4664297103881836e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7628846168518066e+00" rms="4.3107690811157227e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="0" Cut="1.4418191528320312e+02" cType="1" res="1.4735090732574463e+00" rms="8.7885932922363281e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="8" Cut="7.3531180620193481e-02" cType="1" res="1.2593824863433838e+00" rms="8.7176942825317383e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.9387837648391724e-01" rms="8.7978782653808594e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.7314643859863281e-02" rms="8.5601387023925781e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="5" Cut="4.5337982177734375e+01" cType="1" res="4.9805922508239746e+00" rms="9.1933288574218750e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.9452189207077026e-01" rms="9.6264123916625977e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.0516149997711182e+00" rms="7.8946800231933594e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="38">
+      <Node pos="s" depth="0" NCoef="0" IVar="3" Cut="-1.0285543203353882e+00" cType="1" res="1.1978559941053391e-01" rms="8.4920616149902344e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="3" Cut="-2.0734257698059082e+00" cType="1" res="1.4409383535385132e+00" rms="8.4290113449096680e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="7.6867336034774780e-01" cType="1" res="-1.7655850648880005e+00" rms="8.5078210830688477e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.4615388512611389e-01" rms="8.3199367523193359e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.1554813385009766e-01" rms="8.2400054931640625e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="4.7252170562744141e+01" cType="1" res="2.1810901165008545e+00" rms="8.2352285385131836e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.6315725669264793e-03" rms="7.5754113197326660e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.6878659725189209e-01" rms="8.3499660491943359e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="3" Cut="9.3050968647003174e-01" cType="1" res="-3.1567865610122681e-01" rms="8.4676923751831055e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="5" Cut="9.7763204574584961e+00" cType="1" res="-8.8857668638229370e-01" rms="8.4021606445312500e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.6978281140327454e-01" rms="7.6505980491638184e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.2903302013874054e-02" rms="8.7128381729125977e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="3" Cut="2.1199593544006348e+00" cType="1" res="7.9785096645355225e-01" rms="8.4836721420288086e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7397078871726990e-01" rms="8.3738708496093750e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.8953623175621033e-01" rms="8.2593851089477539e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="39">
+      <Node pos="s" depth="0" NCoef="0" IVar="1" Cut="9.2974296569824219e+01" cType="1" res="1.4456325769424438e-01" rms="8.4428081512451172e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="1" Cut="3.0511333465576172e+01" cType="1" res="-2.0321814715862274e-01" rms="8.1323852539062500e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="2.7066835403442383e+01" cType="1" res="-3.0362172126770020e+00" rms="6.8201069831848145e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.5507990121841431e-01" rms="5.8822622299194336e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.9130715131759644e-01" rms="6.8713994026184082e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="3" Cut="-1.0289367437362671e+00" cType="1" res="-3.6801088601350784e-02" rms="8.1724634170532227e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3277745246887207e-01" rms="8.0923404693603516e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.6889904439449310e-02" rms="8.1578674316406250e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="1" Cut="3.7407614135742188e+02" cType="1" res="1.5126788616180420e+00" rms="9.4432182312011719e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="2.1703686714172363e+00" cType="1" res="1.4107741117477417e+00" rms="9.4295339584350586e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.4070537090301514e-01" rms="9.3805265426635742e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.1416354179382324e-01" rms="9.6244106292724609e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0374923706054688e+01" rms="4.8920927047729492e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="40">
+      <Node pos="s" depth="0" NCoef="0" IVar="1" Cut="1.1610852813720703e+02" cType="1" res="1.0750623047351837e-01" rms="8.4345188140869141e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="2" Cut="1.7194017410278320e+01" cType="1" res="-1.1331405490636826e-01" rms="8.2775239944458008e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="4.2162828147411346e-02" cType="1" res="7.2174805402755737e-01" rms="8.0787982940673828e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.0210152268409729e-02" rms="8.0676765441894531e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.0084872245788574e-01" rms="7.9400625228881836e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="3" Cut="-1.2570499181747437e+00" cType="1" res="-5.7940024137496948e-01" rms="8.3501596450805664e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.9626169502735138e-02" rms="8.4625682830810547e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.3521592319011688e-01" rms="8.2959337234497070e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="15" Cut="6.0713446140289307e-01" cType="1" res="1.9517663717269897e+00" rms="9.4469757080078125e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="1.9334352016448975e+00" cType="1" res="3.3030586242675781e+00" rms="9.2553110122680664e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.2388970851898193e-01" rms="9.1448574066162109e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.0492959022521973e-01" rms="9.2443017959594727e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="13" Cut="2.9000000000000000e+01" cType="1" res="9.0943521261215210e-01" rms="9.4612579345703125e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.6088117659091949e-02" rms="9.4299640655517578e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3674460649490356e+00" rms="8.9635581970214844e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="41">
+      <Node pos="s" depth="0" NCoef="0" IVar="1" Cut="1.1240410614013672e+02" cType="1" res="2.3459863662719727e-01" rms="8.4025487899780273e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="3" Cut="-1.2571110725402832e+00" cType="1" res="-3.7239093333482742e-02" rms="8.2026758193969727e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="-2.0735201835632324e+00" cType="1" res="1.3291457891464233e+00" rms="8.1950159072875977e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.2734874486923218e-01" rms="8.4050941467285156e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.8343474864959717e-01" rms="7.9198088645935059e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="2" Cut="1.7997499465942383e+01" cType="1" res="-3.6284074187278748e-01" rms="8.1708574295043945e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.3389765769243240e-02" rms="7.9499258995056152e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.3444000482559204e-01" rms="8.2837696075439453e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="4" Cut="3.9673385620117188e+02" cType="1" res="2.1225585937500000e+00" rms="9.4644498825073242e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="2" Cut="2.7649778366088867e+01" cType="1" res="1.9834831953048706e+00" rms="9.4561195373535156e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.8258254528045654e-01" rms="9.3701791763305664e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.1381406784057617e-01" rms="1.0107668876647949e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.4404582977294922e+00" rms="6.5896139144897461e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="42">
+      <Node pos="s" depth="0" NCoef="0" IVar="5" Cut="1.2430989265441895e+01" cType="1" res="2.5022602081298828e-01" rms="8.3996725082397461e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="12" Cut="3.2323998212814331e-01" cType="1" res="-3.4646305441856384e-01" rms="7.9556574821472168e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="-1.2575930356979370e+00" cType="1" res="-1.0391489267349243e+00" rms="7.7558341026306152e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.4384628310799599e-03" rms="7.8927922248840332e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.7757996916770935e-01" rms="7.6869935989379883e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="6.7566037178039551e-01" cType="1" res="3.8267269730567932e-01" rms="8.0969448089599609e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.0704643800854683e-02" rms="8.0657224655151367e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4729943275451660e+00" rms="5.6514954566955566e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="1" Cut="3.9925732421875000e+02" cType="1" res="8.8195288181304932e-01" rms="8.8015289306640625e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="15" Cut="2.0695614814758301e+00" cType="1" res="8.3201497793197632e-01" rms="8.7892560958862305e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.6559201478958130e-01" rms="8.8166685104370117e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.2090361118316650e-01" rms="8.5388803482055664e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.3045406341552734e+00" rms="3.5489592552185059e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="43">
+      <Node pos="s" depth="0" NCoef="0" IVar="1" Cut="1.1078938293457031e+02" cType="1" res="6.0519121587276459e-02" rms="8.3942346572875977e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="2" Cut="2.3934675216674805e+01" cType="1" res="-1.8143621087074280e-01" rms="8.1769542694091797e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="3.0812604904174805e+01" cType="1" res="1.1791726201772690e-01" rms="8.1232767105102539e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.7959063649177551e-01" rms="7.0754871368408203e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.8790828064084053e-02" rms="8.1642017364501953e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="13" Cut="1.8666666030883789e+01" cType="1" res="-1.6046764850616455e+00" rms="8.2807521820068359e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.3794361054897308e-01" rms="8.2651100158691406e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.7400397062301636e-01" rms="8.0693387985229492e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="1" Cut="1.9077180480957031e+02" cType="1" res="1.6936004161834717e+00" rms="9.5761842727661133e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="4.8721498250961304e-01" cType="1" res="1.2094051837921143e+00" rms="9.4705629348754883e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.0341451168060303e-01" rms="9.4247055053710938e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.3471049070358276e-02" rms="9.4187088012695312e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="13" Cut="2.7428571701049805e+01" cType="1" res="3.7578527927398682e+00" rms="9.7477807998657227e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.3999774456024170e-01" rms="9.9804725646972656e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.2870497703552246e+00" rms="8.3561925888061523e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="44">
+      <Node pos="s" depth="0" NCoef="0" IVar="1" Cut="1.9632084655761719e+02" cType="1" res="1.5256597101688385e-01" rms="8.3499164581298828e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="1" Cut="4.0098731994628906e+01" cType="1" res="5.6886781007051468e-02" rms="8.2988252639770508e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="2.6791654586791992e+01" cType="1" res="-1.1822955608367920e+00" rms="7.5527620315551758e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.0124107599258423e-01" rms="5.4302058219909668e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.3164517283439636e-01" rms="7.5547518730163574e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="2" Cut="1.7032234191894531e+01" cType="1" res="3.9306488633155823e-01" rms="8.4586791992187500e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.5162643790245056e-01" rms="8.3094654083251953e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.3896159604191780e-02" rms="8.5004329681396484e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="1" Cut="3.8078430175781250e+02" cType="1" res="4.0242633819580078e+00" rms="9.4223756790161133e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="17" Cut="2.2857143878936768e+00" cType="1" res="3.3215947151184082e+00" rms="9.4855108261108398e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.5010713338851929e-01" rms="9.2482366561889648e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.4993097782135010e-01" rms="9.7047014236450195e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.5000696182250977e+00" rms="6.0308752059936523e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="45">
+      <Node pos="s" depth="0" NCoef="0" IVar="5" Cut="1.1514787673950195e+01" cType="1" res="1.2198767066001892e-01" rms="8.3178625106811523e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="1" Cut="4.0874591827392578e+01" cType="1" res="-4.8972019553184509e-01" rms="7.8302412033081055e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="13" Cut="1.2714285850524902e+01" cType="1" res="-1.3395720720291138e+00" rms="7.3460445404052734e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.7799121141433716e-02" rms="7.3713240623474121e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.8150135278701782e-01" rms="7.1765670776367188e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="15" Cut="1.4972232580184937e+00" cType="1" res="5.3756911307573318e-02" rms="8.0780353546142578e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.8111878335475922e-02" rms="8.1927909851074219e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.7857675254344940e-01" rms="7.5026655197143555e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="3" Cut="2.1700208187103271e+00" cType="1" res="6.4858001470565796e-01" rms="8.6813554763793945e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="1.0813218355178833e+00" cType="1" res="7.5023102760314941e-01" rms="8.6715087890625000e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.6075286567211151e-02" rms="8.6659955978393555e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.3385840058326721e-01" rms="8.5350332260131836e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="2.6659950613975525e-02" cType="1" res="-2.9267647266387939e+00" rms="8.2600851058959961e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.5181593894958496e-02" rms="7.9300518035888672e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.5839982032775879e-01" rms="8.1400918960571289e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="46">
+      <Node pos="s" depth="0" NCoef="0" IVar="12" Cut="2.3088569939136505e-01" cType="1" res="2.1803683042526245e-01" rms="8.3498363494873047e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="10" Cut="8.4924906492233276e-01" cType="1" res="-4.2984703183174133e-01" rms="8.3413667678833008e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="7" Cut="-8.2581062316894531e+01" cType="1" res="-8.4432959556579590e-01" rms="8.3619852066040039e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.5763955712318420e-01" rms="7.9219455718994141e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.1697367131710052e-02" rms="8.7789707183837891e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="1.5065012872219086e-01" cType="1" res="1.7463517189025879e+00" rms="7.8824043273925781e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1636515706777573e-01" rms="7.7800402641296387e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7125860452651978e+00" rms="4.1002311706542969e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="10" Cut="7.7740329504013062e-01" cType="1" res="6.3792383670806885e-01" rms="8.3284473419189453e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="2.1709401607513428e+00" cType="1" res="5.8181083202362061e-01" rms="8.3198785781860352e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.5045434534549713e-02" rms="8.3061695098876953e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.4466281533241272e-01" rms="7.9687542915344238e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7598277330398560e+00" rms="4.2131662368774414e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="47">
+      <Node pos="s" depth="0" NCoef="0" IVar="12" Cut="2.3141042888164520e-01" cType="1" res="9.6660628914833069e-02" rms="8.3004369735717773e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="7" Cut="1.5932551383972168e+01" cType="1" res="-5.5753511190414429e-01" rms="8.1840829849243164e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="9.7702026367187500e-01" cType="1" res="-9.0270400047302246e-01" rms="8.0153627395629883e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.3510166108608246e-01" rms="7.9822893142700195e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.5195536613464355e+00" rms="6.5654377937316895e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="8" Cut="7.0346757769584656e-02" cType="1" res="1.5198926925659180e+00" rms="8.8541688919067383e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.1037008166313171e-01" rms="8.6960687637329102e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.9797273874282837e-01" rms="8.5315179824829102e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="10" Cut="7.8011792898178101e-01" cType="1" res="5.3069329261779785e-01" rms="8.3485012054443359e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="2.1713626384735107e+00" cType="1" res="4.5980161428451538e-01" rms="8.3308877944946289e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.0382463037967682e-02" rms="8.3162050247192383e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.6607718467712402e-01" rms="7.9952750205993652e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="2.5314128398895264e-01" cType="1" res="1.0794425964355469e+01" rms="2.4817490577697754e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7811748981475830e+00" rms="2.9917328357696533e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.9529819488525391e+00" rms="1.3827517032623291e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="48">
+      <Node pos="s" depth="0" NCoef="0" IVar="16" Cut="1.1163591146469116e+00" cType="1" res="6.9144330918788910e-02" rms="8.2593517303466797e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="15" Cut="1.2125926017761230e+00" cType="1" res="-1.8011935055255890e-01" rms="8.2035865783691406e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="-2.1714744567871094e+00" cType="1" res="1.8824887275695801e-01" rms="8.3022241592407227e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.7666070461273193e-01" rms="8.3262157440185547e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.3149298503994942e-02" rms="8.2845678329467773e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="2.2870460510253906e+02" cType="1" res="-1.0430552959442139e+00" rms="7.9007816314697266e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.6067874431610107e-01" rms="7.8460822105407715e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.6925873756408691e+00" rms="9.4603862762451172e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="15" Cut="2.9905819892883301e+00" cType="1" res="1.0918166637420654e+00" rms="8.4073028564453125e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="-2.1658167839050293e+00" cType="1" res="1.2798920869827271e+00" rms="8.3654260635375977e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.3433842658996582e-01" rms="8.7737054824829102e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.0551887154579163e-01" rms="8.2966127395629883e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="4.5630224049091339e-02" cType="1" res="-1.7254931926727295e+00" rms="8.5286111831665039e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.9706184566020966e-02" rms="8.2177572250366211e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.6603813171386719e-01" rms="8.6367082595825195e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="49">
+      <Node pos="s" depth="0" NCoef="0" IVar="2" Cut="2.3526491165161133e+01" cType="1" res="7.9534806311130524e-02" rms="8.2690591812133789e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="3" Cut="-2.1714427471160889e+00" cType="1" res="3.7154299020767212e-01" rms="8.1878433227539062e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="5.7071244716644287e-01" cType="1" res="-2.8285474777221680e+00" rms="8.2353248596191406e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.8779978752136230e-01" rms="7.7280473709106445e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4140848815441132e-01" rms="8.4173231124877930e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="3" Cut="-1.3000364303588867e+00" cType="1" res="4.7458741068840027e-01" rms="8.1654949188232422e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.6584067940711975e-01" rms="7.9716334342956543e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.2104738317430019e-03" rms="8.1706819534301758e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="14" Cut="4.7619048506021500e-02" cType="1" res="-1.1549986600875854e+00" rms="8.4937257766723633e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="4.8136016845703125e+01" cType="1" res="1.4390803575515747e+00" rms="8.9878759384155273e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.5884558930993080e-03" rms="8.3812732696533203e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.0351604223251343e-01" rms="9.2872304916381836e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="16" Cut="1.1870564222335815e+00" cType="1" res="-1.3184789419174194e+00" rms="8.4349374771118164e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.5611782073974609e-01" rms="8.3481807708740234e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.1395541727542877e-02" rms="8.6592273712158203e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="50">
+      <Node pos="s" depth="0" NCoef="0" IVar="3" Cut="2.1709401607513428e+00" cType="1" res="1.3228897005319595e-02" rms="8.2631616592407227e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="3" Cut="1.0826050043106079e+00" cType="1" res="1.1178712546825409e-01" rms="8.2498865127563477e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="-1.0735369920730591e+00" cType="1" res="-2.1861405670642853e-01" rms="8.2161588668823242e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.7676979601383209e-02" rms="8.3269739151000977e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.0443878173828125e-01" rms="8.1314401626586914e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="2.6014861464500427e-01" cType="1" res="1.4141550064086914e+00" rms="8.2536811828613281e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.6271063834428787e-02" rms="8.1964416503906250e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.6213144659996033e-01" rms="8.1575126647949219e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="11" Cut="3.2816667109727859e-02" cType="1" res="-2.8462896347045898e+00" rms="8.1351966857910156e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="5.0878715515136719e-01" cType="1" res="-4.6834710240364075e-01" rms="8.1262636184692383e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.8389164209365845e-01" rms="7.9425573348999023e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.9071865081787109e-01" rms="7.7985568046569824e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="4" Cut="3.8896251678466797e+01" cType="1" res="-4.1061625480651855e+00" rms="7.8533563613891602e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.9659288227558136e-01" rms="8.1425571441650391e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.9549894332885742e-01" rms="7.5908274650573730e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="51">
+      <Node pos="s" depth="0" NCoef="0" IVar="10" Cut="9.4782239198684692e-01" cType="1" res="6.8165577948093414e-02" rms="8.2574806213378906e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="9" Cut="4.2162828147411346e-02" cType="1" res="1.7674803733825684e-02" rms="8.2518463134765625e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="12" Cut="2.2869169712066650e-01" cType="1" res="-2.0206487178802490e-01" rms="8.2118473052978516e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.4995157718658447e-01" rms="8.0521869659423828e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3825095258653164e-02" rms="8.2652769088745117e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="2" Cut="3.1352346420288086e+01" cType="1" res="1.1741591691970825e+00" rms="8.3646421432495117e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.6963911056518555e-01" rms="8.3259134292602539e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.6797431707382202e-01" rms="8.0087928771972656e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="12" Cut="4.2755931615829468e-02" cType="1" res="5.3274440765380859e+00" rms="7.0674319267272949e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="9.7598630189895630e-01" cType="1" res="2.8516852855682373e+00" rms="7.5934810638427734e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.6403493285179138e-02" rms="7.0663681030273438e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4555542469024658e+00" rms="6.5190353393554688e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="2" Cut="1.8595413208007812e+01" cType="1" res="8.0782871246337891e+00" rms="5.1963195800781250e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2687516212463379e+00" rms="5.4855089187622070e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.2706995010375977e+00" rms="4.6013994216918945e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="52">
+      <Node pos="s" depth="0" NCoef="0" IVar="2" Cut="1.7483800888061523e+01" cType="1" res="1.2544225156307220e-01" rms="8.2017545700073242e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="9" Cut="2.1081414818763733e-01" cType="1" res="6.9888788461685181e-01" rms="8.0425052642822266e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="12" Cut="1.3705559074878693e-01" cType="1" res="5.5949598550796509e-01" rms="8.0308923721313477e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.0628929436206818e-02" rms="7.9163937568664551e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.1500006616115570e-02" rms="8.0346193313598633e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="2" Cut="1.6407724380493164e+01" cType="1" res="2.3168954849243164e+00" rms="8.0003070831298828e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.0453293919563293e-01" rms="7.8334331512451172e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.9453374668955803e-02" rms="8.2093105316162109e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="16" Cut="1.1161266565322876e+00" cType="1" res="-2.2519114613533020e-01" rms="8.2780752182006836e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="2" Cut="2.4679750442504883e+01" cType="1" res="-4.6781980991363525e-01" rms="8.2207269668579102e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.2674642056226730e-02" rms="8.1658105850219727e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.0927396416664124e-01" rms="8.3291044235229492e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="2.2610417175292969e+02" cType="1" res="8.0340331792831421e-01" rms="8.4397974014282227e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.3105506598949432e-02" rms="8.4044408798217773e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.8782398700714111e+00" rms="7.8262071609497070e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="53">
+      <Node pos="s" depth="0" NCoef="0" IVar="2" Cut="1.6342479705810547e+01" cType="1" res="2.5105582550168037e-02" rms="8.2103328704833984e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="12" Cut="1.3721501827239990e-01" cType="1" res="9.9022525548934937e-01" rms="7.9352269172668457e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="1.3754118978977203e-01" cType="1" res="-1.1327182501554489e-01" rms="7.8999161720275879e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.7078171074390411e-02" rms="7.7235417366027832e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.8668432533740997e-01" rms="8.3463668823242188e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="7.5284516811370850e-01" cType="1" res="1.2406104803085327e+00" rms="7.9218502044677734e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0923429578542709e-01" rms="7.9752502441406250e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.5030472278594971e-01" rms="7.3883428573608398e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="12" Cut="2.7332916855812073e-01" cType="1" res="-3.6341905593872070e-01" rms="8.2868413925170898e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="8.2872068881988525e-01" cType="1" res="-9.3088442087173462e-01" rms="8.1548147201538086e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.8420149385929108e-01" rms="8.2039670944213867e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.6931166201829910e-02" rms="7.7442698478698730e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="3" Cut="-2.1714217662811279e+00" cType="1" res="1.7595398426055908e-01" rms="8.3748445510864258e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.9595675468444824e-01" rms="8.1151762008666992e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.2077908739447594e-02" rms="8.3643503189086914e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="54">
+      <Node pos="s" depth="0" NCoef="0" IVar="9" Cut="4.3888181447982788e-02" cType="1" res="1.7137673497200012e-01" rms="8.1967487335205078e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="10" Cut="9.0156000852584839e-01" cType="1" res="-4.9204859882593155e-02" rms="8.1739683151245117e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="3.8789065551757812e+02" cType="1" res="-1.4027048647403717e-01" rms="8.1727247238159180e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.9601478725671768e-02" rms="8.1615629196166992e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.1549782752990723e+00" rms="5.3184051513671875e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="9.7944565117359161e-02" cType="1" res="2.8329875469207764e+00" rms="7.6738214492797852e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7920412123203278e-01" rms="7.6166915893554688e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.6327050924301147e+00" rms="4.2100505828857422e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="13" Cut="1.7000000000000000e+01" cType="1" res="1.4185417890548706e+00" rms="8.2136907577514648e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="8.0487084388732910e-01" cType="1" res="1.7815570831298828e+00" rms="8.0845241546630859e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.2568635642528534e-01" rms="8.0875768661499023e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.8990380764007568e+00" rms="6.0574302673339844e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="7.9516265869140625e+01" cType="1" res="-9.4361891970038414e-03" rms="8.5550174713134766e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.5630489587783813e-01" rms="7.8918633460998535e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.0265378057956696e-01" rms="9.1275463104248047e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="55">
+      <Node pos="s" depth="0" NCoef="0" IVar="15" Cut="2.9731996059417725e+00" cType="1" res="1.3498859107494354e-01" rms="8.1835451126098633e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="5" Cut="1.2282645225524902e+01" cType="1" res="2.3820517957210541e-01" rms="8.1773014068603516e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="12" Cut="6.9265711307525635e-01" cType="1" res="-2.2577893733978271e-01" rms="7.7762961387634277e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.9217326343059540e-02" rms="7.7536072731018066e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.9334442615509033e-01" rms="7.6514964103698730e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="3.8115710020065308e-02" cType="1" res="7.2441637516021729e-01" rms="8.5504503250122070e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.5691646933555603e-01" rms="8.2622413635253906e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.5427894890308380e-02" rms="8.8331995010375977e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="4" Cut="1.6248561096191406e+02" cType="1" res="-1.9025795459747314e+00" rms="8.0389757156372070e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="1.4682589769363403e+00" cType="1" res="-2.1648950576782227e+00" rms="7.8461132049560547e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.4303078055381775e-01" rms="7.6780228614807129e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.6345974057912827e-02" rms="8.4265184402465820e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.0976665019989014e-01" rms="9.7994165420532227e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="56">
+      <Node pos="s" depth="0" NCoef="0" IVar="14" Cut="4.7619048506021500e-02" cType="1" res="3.4065525978803635e-02" rms="8.1838026046752930e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="3" Cut="-2.1703097820281982e+00" cType="1" res="2.1842634677886963e+00" rms="8.0411567687988281e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.3080217242240906e-01" rms="7.6113166809082031e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          <Node pos="r" depth="2" NCoef="0" IVar="13" Cut="1.1857142448425293e+01" cType="1" res="2.4724426269531250e+00" rms="7.9770479202270508e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.2809172868728638e-01" rms="7.7786722183227539e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.8631383776664734e-01" rms="8.0647907257080078e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="12" Cut="6.4033675193786621e-01" cType="1" res="-7.4291437864303589e-02" rms="8.1759729385375977e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="15" Cut="3.3392395973205566e+00" cType="1" res="-1.4644181728363037e-01" rms="8.1714172363281250e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.0457623302936554e-02" rms="8.1638984680175781e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.2692041993141174e-01" rms="8.0890331268310547e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="3.4187927842140198e-01" cType="1" res="2.8523180484771729e+00" rms="7.8160953521728516e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.7797609567642212e-01" rms="7.9281802177429199e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1447259187698364e+00" rms="5.0377092361450195e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="57">
+      <Node pos="s" depth="0" NCoef="0" IVar="7" Cut="-7.9574333190917969e+01" cType="1" res="4.6408448368310928e-02" rms="8.1947326660156250e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="3" Cut="-2.1714277267456055e+00" cType="1" res="-2.4923691153526306e-01" rms="8.0342674255371094e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="6.8379360437393188e-01" cType="1" res="-2.9594786167144775e+00" rms="8.0740270614624023e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.4960185289382935e-01" rms="7.8077712059020996e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.6890099048614502e-01" rms="8.0120458602905273e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="4.6177139878273010e-01" cType="1" res="-1.6110515594482422e-01" rms="8.0176057815551758e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.5305076539516449e-02" rms="7.9560141563415527e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1859916150569916e-01" rms="8.2262744903564453e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="6" Cut="1.3444139957427979e+00" cType="1" res="8.5005110502243042e-01" rms="8.5644102096557617e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="6.3108291625976562e+01" cType="1" res="1.2585049867630005e+00" rms="8.4616537094116211e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.2796995043754578e-02" rms="8.0941686630249023e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.4411066770553589e-01" rms="8.8441572189331055e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="6.8060653686523438e+01" cType="1" res="-2.0857265591621399e-01" rms="8.7367296218872070e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.6540111601352692e-01" rms="8.0509042739868164e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.6483505070209503e-02" rms="9.1645278930664062e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="58">
+      <Node pos="s" depth="0" NCoef="0" IVar="8" Cut="-9.4267158508300781e+01" cType="1" res="1.1316267400979996e-01" rms="8.1984481811523438e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="12" Cut="4.6177139878273010e-01" cType="1" res="-1.8081200122833252e-01" rms="8.0116519927978516e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="6.1695748567581177e-01" cType="1" res="-4.2405164241790771e-01" rms="7.9506688117980957e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.5934155881404877e-01" rms="8.1186466217041016e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.1628219857811928e-02" rms="7.8142690658569336e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="5.5819332599639893e-01" cType="1" res="1.0591913461685181e+00" rms="8.2042541503906250e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.1316513717174530e-02" rms="8.1536254882812500e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.1569132804870605e+00" rms="4.8475664854049683e-01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="1" Cut="1.2329434967041016e+02" cType="1" res="8.8170325756072998e-01" rms="8.6205615997314453e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="8" Cut="7.5678311288356781e-02" cType="1" res="6.4742153882980347e-01" rms="8.4910478591918945e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.8050509691238403e-01" rms="8.5318012237548828e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.3541783690452576e-02" rms="8.3788957595825195e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="7" Cut="7.7720947265625000e+01" cType="1" res="3.1034157276153564e+00" rms="9.4801826477050781e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.0210449695587158e-01" rms="9.3322286605834961e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.3685048818588257e-01" rms="9.7348785400390625e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="59">
+      <Node pos="s" depth="0" NCoef="0" IVar="3" Cut="-1.2571527957916260e+00" cType="1" res="8.2220539450645447e-02" rms="8.1483497619628906e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="3" Cut="-2.0191073417663574e+00" cType="1" res="1.0727607011795044e+00" rms="8.2302694320678711e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="-2.3095862865447998e+00" cType="1" res="-1.1528420448303223e+00" rms="8.3632793426513672e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.1348313093185425e-01" rms="7.7419738769531250e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.5678697526454926e-02" rms="8.3245296478271484e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="3.6503159999847412e-01" cType="1" res="1.9518463611602783e+00" rms="8.0085124969482422e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.9000242650508881e-01" rms="7.9764556884765625e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.3750133514404297e-01" rms="7.9000320434570312e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="3" Cut="1.0067993402481079e+00" cType="1" res="-1.5695676207542419e-01" rms="8.1103324890136719e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="6.9430552423000336e-02" cType="1" res="-5.2975398302078247e-01" rms="8.0939064025878906e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.2562379240989685e-01" rms="8.0379009246826172e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0960710793733597e-01" rms="8.2790813446044922e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="3" Cut="2.1345727443695068e+00" cType="1" res="7.0989900827407837e-01" rms="8.0821924209594727e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4962290227413177e-01" rms="8.0501194000244141e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.6199820637702942e-01" rms="7.7802147865295410e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="60">
+      <Node pos="s" depth="0" NCoef="0" IVar="3" Cut="-1.2562371492385864e+00" cType="1" res="2.0107433199882507e-01" rms="8.1146736145019531e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="3" Cut="-2.0179555416107178e+00" cType="1" res="1.1340516805648804e+00" rms="7.9962587356567383e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="12" Cut="6.2090373039245605e-01" cType="1" res="-1.0923138856887817e+00" rms="8.0087432861328125e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.1380209922790527e-01" rms="7.9283685684204102e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.6819937229156494e-01" rms="7.5664858818054199e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="2.3386353254318237e-01" cType="1" res="1.9943852424621582e+00" rms="7.8235125541687012e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.9671930074691772e-02" rms="7.6668286323547363e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.8900250196456909e-01" rms="7.8560547828674316e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="3" Cut="1.1811271905899048e+00" cType="1" res="-1.8913719803094864e-02" rms="8.1267538070678711e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="3.0848050117492676e-01" cType="1" res="-2.7706691622734070e-01" rms="8.1102771759033203e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.5199785828590393e-01" rms="8.3308801651000977e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.0747753381729126e-02" rms="8.0613975524902344e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="3" Cut="2.0517714023590088e+00" cType="1" res="7.4227339029312134e-01" rms="8.1275491714477539e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.9064967334270477e-01" rms="8.0552282333374023e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.2728228569030762e-01" rms="7.8944783210754395e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="61">
+      <Node pos="s" depth="0" NCoef="0" IVar="1" Cut="5.5250717163085938e+01" cType="1" res="1.8087315559387207e-01" rms="8.1535768508911133e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="4" Cut="5.1851982116699219e+01" cType="1" res="-2.5809931755065918e-01" rms="7.4740114212036133e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="1.2573428153991699e+00" cType="1" res="-6.3214413821697235e-02" rms="7.4663701057434082e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.6492266952991486e-02" rms="7.4357872009277344e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.5899194777011871e-01" rms="7.4192452430725098e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="5.1932678222656250e+01" cType="1" res="-2.6984097957611084e+00" rms="7.1315984725952148e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.6174145936965942e-01" rms="5.3946342468261719e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.4012927711009979e-01" rms="7.2313356399536133e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="3" Cut="2.1703686714172363e+00" cType="1" res="5.4141759872436523e-01" rms="8.6553525924682617e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="13" Cut="1.4380952835083008e+01" cType="1" res="6.4375334978103638e-01" rms="8.6456346511840820e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.6287852823734283e-01" rms="8.4486742019653320e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2106176465749741e-02" rms="8.7661294937133789e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="5.3221553564071655e-01" cType="1" res="-2.4945430755615234e+00" rms="8.3889894485473633e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.0067957639694214e-01" rms="8.2769136428833008e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2097303569316864e-01" rms="7.8042607307434082e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="62">
+      <Node pos="s" depth="0" NCoef="0" IVar="1" Cut="2.0020988464355469e+02" cType="1" res="2.1676680445671082e-01" rms="8.1433553695678711e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="1" Cut="3.2055690765380859e+01" cType="1" res="1.5692320466041565e-01" rms="8.0979204177856445e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="3.1592746734619141e+01" cType="1" res="-1.6057780981063843e+00" rms="6.7857513427734375e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.7541761696338654e-01" rms="6.7858190536499023e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.9183495044708252e-01" rms="4.1850051879882812e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="13" Cut="1.9619047164916992e+01" cType="1" res="2.9021313786506653e-01" rms="8.1731500625610352e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.8693023622035980e-02" rms="8.1064720153808594e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.5460826456546783e-01" rms="8.4780015945434570e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="1" Cut="3.7889108276367188e+02" cType="1" res="2.7357318401336670e+00" rms="9.5330781936645508e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="3.1011581420898438e+02" cType="1" res="2.1000812053680420e+00" rms="9.5751810073852539e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.1611503362655640e-01" rms="9.4041051864624023e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.5499382019042969e-01" rms="1.0113402366638184e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.5647077560424805e+00" rms="6.9405980110168457e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="63">
+      <Node pos="s" depth="0" NCoef="0" IVar="1" Cut="1.7988377380371094e+02" cType="1" res="1.6569787263870239e-01" rms="8.1170892715454102e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="1" Cut="3.1514730453491211e+01" cType="1" res="9.1883026063442230e-02" rms="8.0634498596191406e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="13" Cut="8.6666669845581055e+00" cType="1" res="-1.5209481716156006e+00" rms="6.7173585891723633e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.9721258431673050e-02" rms="6.7311091423034668e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.4199354648590088e-01" rms="6.6025433540344238e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="13" Cut="1.9619047164916992e+01" cType="1" res="2.0191140472888947e-01" rms="8.1355390548706055e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.3771637827157974e-02" rms="8.0601091384887695e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.5332333743572235e-01" rms="8.5284376144409180e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="13" Cut="3.1142856597900391e+01" cType="1" res="2.6158702373504639e+00" rms="9.4080924987792969e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="5" Cut="9.3024925231933594e+01" cType="1" res="2.2003607749938965e+00" rms="9.4523401260375977e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.5060261487960815e-01" rms="9.2976818084716797e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.7521243691444397e-01" rms="1.0238779067993164e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.2082357406616211e+00" rms="6.8383636474609375e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="64">
+      <Node pos="s" depth="0" NCoef="0" IVar="3" Cut="-1.0286139249801636e+00" cType="1" res="1.4854702353477478e-01" rms="8.0900163650512695e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="3" Cut="-2.2040169239044189e+00" cType="1" res="8.9987158775329590e-01" rms="8.0123529434204102e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="5.2098064422607422e+01" cType="1" res="-1.7472862005233765e+00" rms="7.8949742317199707e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.7946213036775589e-02" rms="7.6137609481811523e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.1201856732368469e-01" rms="7.9019675254821777e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="3.8181522488594055e-01" cType="1" res="1.2416596412658691e+00" rms="7.9634976387023926e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3649077713489532e-01" rms="7.9440760612487793e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.7435234785079956e-01" rms="7.9580640792846680e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="3" Cut="1.2568295001983643e+00" cType="1" res="-8.8172353804111481e-02" rms="8.0999069213867188e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="3.4599322825670242e-02" cType="1" res="-3.9751142263412476e-01" rms="8.0400056838989258e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.0566228628158569e-01" rms="7.9906554222106934e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2165699154138565e-01" rms="8.1666593551635742e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="3" Cut="1.9642710685729980e+00" cType="1" res="8.4315896034240723e-01" rms="8.2075462341308594e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.2717098891735077e-01" rms="8.0865468978881836e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.5697012841701508e-01" rms="8.1529083251953125e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="65">
+      <Node pos="s" depth="0" NCoef="0" IVar="15" Cut="2.7321050167083740e+00" cType="1" res="1.2519930303096771e-01" rms="8.0948801040649414e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="16" Cut="5.9352821111679077e-01" cType="1" res="2.3956143856048584e-01" rms="8.1115818023681641e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="5.8192649841308594e+01" cType="1" res="-3.5863500088453293e-02" rms="8.0662775039672852e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.9527812302112579e-02" rms="7.5273728370666504e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.7741995900869370e-02" rms="8.6521425247192383e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="4" Cut="1.0235220336914062e+02" cType="1" res="8.4243971109390259e-01" rms="8.1775655746459961e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3205018639564514e-01" rms="7.8322472572326660e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.7620232701301575e-02" rms="9.2409496307373047e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="11" Cut="4.9219455569982529e-02" cType="1" res="-1.3958172798156738e+00" rms="7.7097091674804688e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="8.0363196134567261e-01" cType="1" res="-6.8855452537536621e-01" rms="7.5486435890197754e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.6112779080867767e-01" rms="7.6598367691040039e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.8341851681470871e-02" rms="7.2029933929443359e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="2.4642091989517212e-01" cType="1" res="-2.9440619945526123e+00" rms="7.8311805725097656e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.0510835647583008e-01" rms="7.4705915451049805e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.7956039458513260e-03" rms="8.4081735610961914e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="66">
+      <Node pos="s" depth="0" NCoef="0" IVar="3" Cut="-2.1714437007904053e+00" cType="1" res="1.3303510844707489e-01" rms="8.1179819107055664e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="10" Cut="6.5543848276138306e-01" cType="1" res="-2.0261540412902832e+00" rms="8.1247997283935547e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="6.9247924804687500e+01" cType="1" res="-2.8435053825378418e+00" rms="7.9376988410949707e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.4187214672565460e-01" rms="7.7984442710876465e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.9349443912506104e-01" rms="7.8708682060241699e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="3" Cut="-2.2869222164154053e+00" cType="1" res="1.7200392484664917e+00" rms="7.9177498817443848e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.7561994791030884e-01" rms="7.6863970756530762e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.0668946206569672e-02" rms="7.5289320945739746e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="3" Cut="-1.3005003929138184e+00" cType="1" res="2.0812369883060455e-01" rms="8.1074047088623047e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="12" Cut="8.9288175106048584e-02" cType="1" res="1.3057347536087036e+00" rms="7.9951362609863281e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.4970973134040833e-01" rms="7.7422504425048828e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.0396251976490021e-01" rms="7.9834914207458496e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="3.6714044213294983e-01" cType="1" res="1.1257853358983994e-02" rms="8.1116838455200195e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.4831888526678085e-02" rms="8.0694789886474609e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.2658024728298187e-02" rms="8.1783323287963867e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="67">
+      <Node pos="s" depth="0" NCoef="0" IVar="1" Cut="3.9916790771484375e+02" cType="1" res="1.2594924867153168e-01" rms="8.0758800506591797e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="2" Cut="1.5229804039001465e+01" cType="1" res="1.0398035496473312e-01" rms="8.0686416625976562e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="12" Cut="4.5366257429122925e-01" cType="1" res="9.0824812650680542e-01" rms="7.8471360206604004e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.5717143714427948e-02" rms="7.8448691368103027e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.6171126961708069e-01" rms="7.7520036697387695e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="4.1525566101074219e+01" cType="1" res="-1.0169925540685654e-01" rms="8.1115245819091797e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.1102312058210373e-01" rms="7.3635401725769043e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.0174450948834419e-03" rms="8.3100509643554688e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0439517974853516e+01" rms="4.6231060028076172e+00" purity="1.0000000000000000e+00" nType="-99"/>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="68">
+      <Node pos="s" depth="0" NCoef="0" IVar="15" Cut="2.4285378456115723e+00" cType="1" res="5.0845317542552948e-02" rms="8.0306863784790039e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="1" Cut="2.0570091247558594e+02" cType="1" res="1.9110983610153198e-01" rms="8.0363969802856445e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="16" Cut="1.0366895198822021e+00" cType="1" res="1.3139732182025909e-01" rms="7.9957032203674316e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.9855187982320786e-02" rms="7.9306492805480957e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0772578418254852e-01" rms="8.1993951797485352e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="4.0015551757812500e+02" cType="1" res="3.2644653320312500e+00" rms="9.4092216491699219e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.3862369060516357e-01" rms="9.4882020950317383e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.3831539154052734e+00" rms="6.5044040679931641e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="11" Cut="2.4609727784991264e-02" cType="1" res="-1.1680049896240234e+00" rms="7.8764266967773438e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="1.4748883247375488e+00" cType="1" res="-3.8096535205841064e-01" rms="7.4871215820312500e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.8180167376995087e-02" rms="7.3255081176757812e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.4126129746437073e-01" rms="8.1684551239013672e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="5.4530747234821320e-02" cType="1" res="-1.9302145242691040e+00" rms="8.1639242172241211e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.5473924875259399e-01" rms="8.0568103790283203e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2163420766592026e-01" rms="8.2731218338012695e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="69">
+      <Node pos="s" depth="0" NCoef="0" IVar="2" Cut="2.1158575057983398e+01" cType="1" res="1.6398103535175323e-01" rms="8.0284004211425781e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="1" Cut="1.6835870361328125e+02" cType="1" res="4.4624277949333191e-01" rms="7.8882842063903809e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="2.9311639785766602e+01" cType="1" res="3.7073737382888794e-01" rms="7.8214559555053711e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.0843775570392609e-01" rms="6.1437115669250488e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.3497730046510696e-02" rms="7.8661603927612305e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="15" Cut="1.7848565578460693e+00" cType="1" res="2.3163528442382812e+00" rms="9.1972389221191406e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.1066406965255737e-01" rms="8.9580621719360352e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.5248049795627594e-02" rms="9.4935445785522461e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="12" Cut="6.0335534811019897e-01" cType="1" res="-3.9276921749114990e-01" rms="8.2696456909179688e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="14" Cut="4.7619048506021500e-02" cType="1" res="-5.1270967721939087e-01" rms="8.2498445510864258e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.2396308183670044e-01" rms="8.3318042755126953e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.0309928655624390e-01" rms="8.2312994003295898e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="3" Cut="-7.7838826179504395e-01" cType="1" res="2.1965816020965576e+00" rms="8.2724475860595703e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.1556407213211060e-01" rms="7.1496877670288086e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0646347701549530e-01" rms="8.4250059127807617e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="70">
+      <Node pos="s" depth="0" NCoef="0" IVar="14" Cut="4.7619048506021500e-02" cType="1" res="7.9564832150936127e-02" rms="8.0377750396728516e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="3" Cut="-2.1630120277404785e+00" cType="1" res="1.8769528865814209e+00" rms="8.2336349487304688e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.0153702795505524e-01" rms="7.3748331069946289e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="3.8294784724712372e-02" cType="1" res="2.0910484790802002e+00" rms="8.2346858978271484e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.5367017388343811e-01" rms="7.7010326385498047e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.9330464303493500e-01" rms="8.4847021102905273e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="10" Cut="7.7883398532867432e-01" cType="1" res="-1.0290250182151794e-02" rms="8.0172891616821289e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="7" Cut="-7.9574333190917969e+01" cType="1" res="-1.8414266407489777e-01" rms="8.0945405960083008e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.9692192375659943e-02" rms="7.8821063041687012e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.7942012548446655e-02" rms="8.4946813583374023e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="1.9884741306304932e-01" cType="1" res="9.3272560834884644e-01" rms="7.5148062705993652e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.5147730484604836e-02" rms="7.4210662841796875e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.0653327703475952e-01" rms="6.7247028350830078e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="71">
+      <Node pos="s" depth="0" NCoef="0" IVar="12" Cut="3.2397460937500000e-01" cType="1" res="1.3196779787540436e-01" rms="8.0690307617187500e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="10" Cut="7.8918874263763428e-01" cType="1" res="-1.9300748407840729e-01" rms="8.0119590759277344e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="8" Cut="-9.4267211914062500e+01" cType="1" res="-4.5284011960029602e-01" rms="8.1365871429443359e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.2507873773574829e-01" rms="7.8181571960449219e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.1850108429789543e-03" rms="8.5760517120361328e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="2.1809071302413940e-01" cType="1" res="7.5064009428024292e-01" rms="7.4663710594177246e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.0411442518234253e-02" rms="7.3798575401306152e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.6114606857299805e+00" rms="3.2177016735076904e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="10" Cut="6.8669390678405762e-01" cType="1" res="6.7829996347427368e-01" rms="8.1348724365234375e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="5" Cut="9.4731216430664062e+00" cType="1" res="5.6612998247146606e-01" rms="8.1129646301269531e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.1345300897955894e-03" rms="7.6790843009948730e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.6850098967552185e-01" rms="8.4911270141601562e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="7.1200537681579590e-01" cType="1" res="1.0080410957336426e+01" rms="2.5608434677124023e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3550357818603516e+00" rms="3.0970811843872070e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.5865645408630371e+00" rms="9.8998808860778809e-01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="72">
+      <Node pos="s" depth="0" NCoef="0" IVar="10" Cut="9.4290858507156372e-01" cType="1" res="1.7841269075870514e-01" rms="8.0124311447143555e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="12" Cut="1.3884626328945160e-01" cType="1" res="1.4383721351623535e-01" rms="8.0070991516113281e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="16" Cut="1.8572654724121094e+00" cType="1" res="-6.7870962619781494e-01" rms="7.8704619407653809e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.3612475991249084e-01" rms="7.7417306900024414e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.9478715956211090e-01" rms="8.5568895339965820e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="8.3997708559036255e-01" cType="1" res="3.0313792824745178e-01" rms="8.0235509872436523e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.0014513283967972e-02" rms="8.0292224884033203e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.5896905660629272e-01" rms="6.9980463981628418e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="12" Cut="4.5754250138998032e-02" cType="1" res="3.5222110748291016e+00" rms="7.8206629753112793e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="16" Cut="5.8450669050216675e-01" cType="1" res="4.5318177342414856e-01" rms="7.6624846458435059e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.0212378501892090e-01" rms="7.6050519943237305e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.5235855579376221e-01" rms="6.9031467437744141e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="6.6643133759498596e-02" cType="1" res="7.2842469215393066e+00" rms="6.2021112442016602e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.6069217920303345e-01" rms="7.2788696289062500e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.3534650802612305e+00" rms="3.3736422061920166e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="73">
+      <Node pos="s" depth="0" NCoef="0" IVar="10" Cut="9.4290590286254883e-01" cType="1" res="9.8782569169998169e-02" rms="8.0339622497558594e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="12" Cut="1.3884626328945160e-01" cType="1" res="5.7571232318878174e-02" rms="8.0304269790649414e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="8" Cut="-9.4267158508300781e+01" cType="1" res="-7.3163360357284546e-01" rms="7.8592438697814941e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.8352152407169342e-01" rms="7.3592219352722168e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3921219215262681e-04" rms="8.4201660156250000e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="8.4589934349060059e-01" cType="1" res="2.1446107327938080e-01" rms="8.0548162460327148e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.4584381026215851e-04" rms="8.0541572570800781e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.3670202493667603e-01" rms="6.0571355819702148e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="12" Cut="4.8972282558679581e-02" cType="1" res="3.7588644027709961e+00" rms="7.4860424995422363e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="9.6311610937118530e-01" cType="1" res="1.1384637355804443e+00" rms="7.5132093429565430e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.4151479601860046e-01" rms="7.2193894386291504e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.5816547274589539e-01" rms="7.0229415893554688e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="6.3750356435775757e-02" cType="1" res="7.5185694694519043e+00" rms="5.6097116470336914e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.6001727581024170e-01" rms="6.5423188209533691e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.1106798648834229e+00" rms="3.8735501766204834e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="74">
+      <Node pos="s" depth="0" NCoef="0" IVar="2" Cut="2.1262792587280273e+01" cType="1" res="1.6275566071271896e-02" rms="7.9982867240905762e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="3" Cut="1.2569915056228638e+00" cType="1" res="3.2539033889770508e-01" rms="7.9071841239929199e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="5.3632259368896484e+01" cType="1" res="1.4156822860240936e-01" rms="7.8702635765075684e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.8161661028862000e-02" rms="7.1576261520385742e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.0125713944435120e-02" rms="8.3560028076171875e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="3" Cut="2.0190520286560059e+00" cType="1" res="1.1577683687210083e+00" rms="8.0196876525878906e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.5324055552482605e-01" rms="7.9016904830932617e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.1700194329023361e-01" rms="8.0496006011962891e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="12" Cut="6.4249581098556519e-01" cType="1" res="-6.3459783792495728e-01" rms="8.1485481262207031e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="15" Cut="2.2749280929565430e+00" cType="1" res="-7.2187805175781250e-01" rms="8.1252336502075195e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.1291777789592743e-02" rms="8.1690082550048828e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.8491863608360291e-01" rms="7.6871280670166016e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="2.7090993523597717e-01" cType="1" res="2.2691996097564697e+00" rms="8.3866920471191406e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2063435278832912e-02" rms="8.0733852386474609e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.7104681730270386e-01" rms="8.2126197814941406e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="75">
+      <Node pos="s" depth="0" NCoef="0" IVar="13" Cut="1.0428571701049805e+01" cType="1" res="1.4687426388263702e-01" rms="7.9903044700622559e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="3" Cut="-2.1713383197784424e+00" cType="1" res="7.5840860605239868e-01" rms="7.7931499481201172e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="9.4204437255859375e+01" cType="1" res="-1.4380059242248535e+00" rms="7.9611496925354004e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.4117997884750366e-01" rms="7.9081239700317383e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.2678381204605103e-01" rms="7.3149976730346680e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="3" Cut="1.9645241498947144e+00" cType="1" res="9.2764484882354736e-01" rms="7.7542824745178223e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3760213553905487e-01" rms="7.7299847602844238e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.3346415758132935e-01" rms="7.6667785644531250e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="1" Cut="6.6591751098632812e+01" cType="1" res="-3.0757792294025421e-02" rms="8.0379514694213867e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="1.4780533313751221e+00" cType="1" res="-4.0616312623023987e-01" rms="7.4379568099975586e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.9578911662101746e-02" rms="7.4166393280029297e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3595782220363617e-01" rms="7.4034800529479980e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="1.7416714131832123e-01" cType="1" res="4.1374441981315613e-01" rms="8.6740274429321289e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.4041003584861755e-02" rms="8.5561218261718750e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.8876135647296906e-02" rms="8.6986665725708008e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="76">
+      <Node pos="s" depth="0" NCoef="0" IVar="15" Cut="1.2125926017761230e+00" cType="1" res="5.5240280926227570e-02" rms="8.0288944244384766e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="3" Cut="1.9427890777587891e+00" cType="1" res="3.2069024443626404e-01" rms="8.0580215454101562e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="1.3220087289810181e+00" cType="1" res="4.4515109062194824e-01" rms="8.0523777008056641e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4445967040956020e-02" rms="8.0320920944213867e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.6041662693023682e-01" rms="8.0387926101684570e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="4.5314559340476990e-01" cType="1" res="-1.2577831745147705e+00" rms="7.9622068405151367e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.6588069796562195e-01" rms="7.7567682266235352e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.2572945803403854e-02" rms="7.9133210182189941e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="10" Cut="8.0231362581253052e-01" cType="1" res="-4.4031980633735657e-01" rms="7.9505515098571777e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="3.2024484127759933e-02" cType="1" res="-6.5258276462554932e-01" rms="7.9929099082946777e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.4623944908380508e-02" rms="7.8312382698059082e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.7014232277870178e-01" rms="8.1041679382324219e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="2.0025861263275146e-01" cType="1" res="5.7030534744262695e-01" rms="7.6655039787292480e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.0166623704135418e-04" rms="7.5811948776245117e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7765483856201172e+00" rms="3.8464100360870361e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="77">
+      <Node pos="s" depth="0" NCoef="0" IVar="14" Cut="4.7619048506021500e-02" cType="1" res="1.3517713546752930e-01" rms="8.0207738876342773e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="3" Cut="1.7145055532455444e+00" cType="1" res="1.8070607185363770e+00" rms="8.2683868408203125e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="2.6806351542472839e-01" cType="1" res="2.4297902584075928e+00" rms="8.0454845428466797e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.8363445401191711e-01" rms="8.0052728652954102e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.9467837810516357e-01" rms="7.5916123390197754e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="9.5729291439056396e-02" cType="1" res="-6.1990112066268921e-01" rms="8.6681547164916992e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.3291903734207153e-01" rms="8.5435829162597656e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.8019856810569763e-01" rms="8.3023509979248047e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="7" Cut="-7.9574333190917969e+01" cType="1" res="5.6436862796545029e-02" rms="8.0003128051757812e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="7.7076721191406250e-01" cType="1" res="-1.9276046752929688e-01" rms="7.7689433097839355e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.1694619953632355e-02" rms="7.8534326553344727e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.5975531935691833e-02" rms="7.3645038604736328e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="2" Cut="1.3905488967895508e+01" cType="1" res="6.7584055662155151e-01" rms="8.5167913436889648e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.3515116572380066e-01" rms="7.9334545135498047e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.3428324162960052e-02" rms="8.5739192962646484e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="78">
+      <Node pos="s" depth="0" NCoef="0" IVar="10" Cut="7.8686732053756714e-01" cType="1" res="1.4987514913082123e-01" rms="8.0311155319213867e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="12" Cut="1.8470856547355652e-01" cType="1" res="1.1969948187470436e-02" rms="8.0971555709838867e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="6" Cut="-9.3420959472656250e+01" cType="1" res="-8.3401203155517578e-01" rms="8.1461181640625000e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.6221799850463867e-01" rms="7.7500772476196289e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.0832393094897270e-02" rms="8.3470239639282227e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="3.3869162201881409e-02" cType="1" res="2.1209011971950531e-01" rms="8.0725736618041992e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.2037830464541912e-03" rms="8.0372629165649414e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.5924979746341705e-01" rms="8.2241373062133789e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="12" Cut="2.1846087276935577e-01" cType="1" res="1.0049771070480347e+00" rms="7.5528345108032227e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="12" Cut="1.6633625328540802e-01" cType="1" res="6.8301165103912354e-01" rms="7.4785633087158203e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.9973834753036499e-03" rms="7.5274062156677246e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.3231419920921326e-01" rms="7.1594219207763672e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="5.3297706604003906e+01" cType="1" res="8.9289045333862305e+00" rms="4.3796353340148926e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2264455556869507e+00" rms="5.0319261550903320e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.7131237983703613e+00" rms="1.4779189825057983e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="79">
+      <Node pos="s" depth="0" NCoef="0" IVar="10" Cut="8.4924906492233276e-01" cType="1" res="3.7747398018836975e-02" rms="8.0156402587890625e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="12" Cut="1.8512834608554840e-01" cType="1" res="-5.5761683732271194e-02" rms="8.0405626296997070e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="1.3166454434394836e-01" cType="1" res="-8.3647793531417847e-01" rms="7.9286580085754395e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.8007159233093262e-01" rms="7.7605428695678711e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1216329783201218e-01" rms="8.3186902999877930e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="8.0904966592788696e-01" cType="1" res="1.7244517803192139e-01" rms="8.0587072372436523e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.1645169258117676e-03" rms="8.0517997741699219e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0017864704132080e+00" rms="5.3837046623229980e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="12" Cut="1.6570617258548737e-01" cType="1" res="1.4017809629440308e+00" rms="7.5116682052612305e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="12" Cut="1.4987768232822418e-01" cType="1" res="1.0213528871536255e+00" rms="7.4264149665832520e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.5000742673873901e-02" rms="7.3797893524169922e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1314719915390015e+00" rms="5.8194255828857422e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.9703967571258545e+00" rms="3.7559323310852051e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="80">
+      <Node pos="s" depth="0" NCoef="0" IVar="10" Cut="9.6957659721374512e-01" cType="1" res="5.7051494717597961e-02" rms="8.0016641616821289e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="12" Cut="7.2586011886596680e-01" cType="1" res="3.4058958292007446e-02" rms="7.9960899353027344e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="3.8011737167835236e-02" cType="1" res="-6.3703744672238827e-04" rms="7.9919772148132324e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.7876565009355545e-02" rms="7.9418540000915527e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.0129174292087555e-02" rms="8.2072219848632812e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="8.3404332399368286e-01" cType="1" res="3.5612504482269287e+00" rms="7.6196041107177734e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.8085788488388062e-01" rms="7.6686458587646484e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.6382790803909302e-01" rms="7.1661667823791504e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="3" Cut="-4.5865583419799805e-01" cType="1" res="5.7277965545654297e+00" rms="7.3301835060119629e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.6041536331176758e+00" rms="7.7538056373596191e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4897201061248779e+00" rms="6.7919292449951172e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="81">
+      <Node pos="s" depth="0" NCoef="0" IVar="1" Cut="6.6591751098632812e+01" cType="1" res="1.1784569919109344e-01" rms="8.0004386901855469e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="4" Cut="6.4418601989746094e+01" cType="1" res="-2.0392410457134247e-01" rms="7.4912257194519043e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="2.8706384658813477e+01" cType="1" res="-1.0381808131933212e-01" rms="7.4757513999938965e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.2781273126602173e-01" rms="5.8948965072631836e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.4592410996556282e-02" rms="7.5061535835266113e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="6.4150604248046875e+01" cType="1" res="-3.1453206539154053e+00" rms="7.3469214439392090e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.5701197385787964e-01" rms="5.5605912208557129e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.1487124264240265e-01" rms="7.4911751747131348e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="3" Cut="1.9423726797103882e+00" cType="1" res="5.6932955980300903e-01" rms="8.6444520950317383e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="17" Cut="2.3809523582458496e+00" cType="1" res="7.1097737550735474e-01" rms="8.6317567825317383e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.9173680245876312e-01" rms="8.7502202987670898e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.3011416718363762e-03" rms="8.4275341033935547e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="2.6010820269584656e-01" cType="1" res="-1.6493461132049561e+00" rms="8.5396203994750977e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.1096342802047729e-01" rms="7.8953809738159180e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.0034226775169373e-01" rms="8.5354776382446289e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="82">
+      <Node pos="s" depth="0" NCoef="0" IVar="2" Cut="2.5042207717895508e+01" cType="1" res="9.2847682535648346e-02" rms="7.9905610084533691e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="12" Cut="2.7769252657890320e-01" cType="1" res="2.4241800606250763e-01" rms="7.9456410408020020e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="7.7172160148620605e-01" cType="1" res="-1.3344548642635345e-01" rms="7.8758649826049805e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.9465515911579132e-02" rms="8.0319356918334961e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.9822507202625275e-02" rms="7.4660296440124512e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="7.2840642929077148e-01" cType="1" res="6.5245091915130615e-01" rms="8.0009565353393555e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.8005712926387787e-02" rms="7.9829754829406738e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.6901199817657471e+00" rms="3.4864211082458496e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="1" Cut="5.2584205627441406e+01" cType="1" res="-8.9979690313339233e-01" rms="8.2137737274169922e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="16" Cut="3.4001898765563965e-01" cType="1" res="-1.8566679954528809e+00" rms="7.6205844879150391e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.5303163528442383e-01" rms="7.5500779151916504e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.5868332013487816e-02" rms="7.4717407226562500e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="3" Cut="-1.9419364929199219e+00" cType="1" res="-3.4733489155769348e-01" rms="8.4885368347167969e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.2713162302970886e-01" rms="8.4584207534790039e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.0868727713823318e-02" rms="8.4645423889160156e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="83">
+      <Node pos="s" depth="0" NCoef="0" IVar="2" Cut="3.3424736022949219e+01" cType="1" res="4.0737777948379517e-02" rms="7.9558157920837402e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="9" Cut="2.6332908868789673e-01" cType="1" res="7.5462847948074341e-02" rms="7.9488725662231445e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="-2.1714277267456055e+00" cType="1" res="-2.6638244744390249e-03" rms="7.9202637672424316e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.6099815964698792e-01" rms="8.2227001190185547e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.4905343353748322e-03" rms="7.9045095443725586e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="6.5560928344726562e+01" cType="1" res="1.3894304037094116e+00" rms="8.3060789108276367e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.9809454977512360e-02" rms="7.8464498519897461e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.0048893690109253e-01" rms="8.9042129516601562e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="3" Cut="-5.7770913839340210e-01" cType="1" res="-3.2069528102874756e+00" rms="7.9348783493041992e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.7947053574025631e-03" rms="8.3151750564575195e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="5.2132171630859375e+01" cType="1" res="-4.4270377159118652e+00" rms="7.4411106109619141e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.7905079126358032e-01" rms="8.1696958541870117e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.5170683860778809e-01" rms="6.7418365478515625e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="84">
+      <Node pos="s" depth="0" NCoef="0" IVar="10" Cut="8.8792002201080322e-01" cType="1" res="4.7618154436349869e-02" rms="7.9796271324157715e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="16" Cut="1.1163591146469116e+00" cType="1" res="-1.5741970390081406e-02" rms="7.9840807914733887e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="2" Cut="1.4969063758850098e+01" cType="1" res="-1.6651900112628937e-01" rms="7.9365129470825195e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.5202244073152542e-02" rms="7.7216367721557617e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.9347275644540787e-02" rms="7.9771819114685059e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="6" Cut="-9.3305648803710938e+01" cType="1" res="6.1220806837081909e-01" rms="8.1492671966552734e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1815695092082024e-02" rms="7.8865242004394531e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.7895039319992065e-01" rms="8.6440086364746094e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="12" Cut="1.0688982903957367e-01" cType="1" res="1.6912543773651123e+00" rms="7.6827354431152344e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="12" Cut="5.0818149000406265e-02" cType="1" res="4.6117582917213440e-01" rms="7.5617275238037109e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.5453639030456543e-01" rms="6.9557051658630371e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.0557463169097900e-01" rms="7.5843310356140137e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="9.0503096580505371e-01" cType="1" res="7.8219656944274902e+00" rms="4.8053669929504395e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.1136119365692139e-01" rms="5.3180155754089355e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.0129611492156982e+00" rms="3.1430435180664062e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="85">
+      <Node pos="s" depth="0" NCoef="0" IVar="3" Cut="-2.1700699329376221e+00" cType="1" res="1.2456934154033661e-01" rms="7.9852452278137207e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="3" Cut="-2.2788815498352051e+00" cType="1" res="-1.8851162195205688e+00" rms="7.8469786643981934e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="5.6713199615478516e-01" cType="1" res="-3.4927361011505127e+00" rms="7.3389382362365723e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.7943052053451538e-01" rms="7.0336604118347168e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.5180307477712631e-02" rms="7.6769309043884277e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="4.1566494107246399e-01" cType="1" res="-2.6702341437339783e-01" rms="8.0075521469116211e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.1840323507785797e-01" rms="7.7829794883728027e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.0951076149940491e-01" rms="7.6492381095886230e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="12" Cut="2.3088569939136505e-01" cType="1" res="1.8864959478378296e-01" rms="7.9812941551208496e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="7" Cut="-8.5446113586425781e+01" cType="1" res="-2.4154525995254517e-01" rms="7.8679504394531250e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.0396507382392883e-01" rms="7.5291814804077148e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.9754635691642761e-02" rms="8.3945636749267578e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="7.0755738019943237e-01" cType="1" res="4.7220724821090698e-01" rms="8.0425586700439453e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.8625128790736198e-02" rms="8.0722131729125977e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.9429841041564941e-01" rms="7.4916357994079590e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="86">
+      <Node pos="s" depth="0" NCoef="0" IVar="10" Cut="8.8630789518356323e-01" cType="1" res="9.4106547534465790e-02" rms="7.9658761024475098e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="12" Cut="2.3088569939136505e-01" cType="1" res="2.5150593370199203e-02" rms="7.9794564247131348e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="7" Cut="1.5932551383972168e+01" cType="1" res="-3.9630627632141113e-01" rms="7.8955430984497070e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.0211823582649231e-02" rms="7.7044324874877930e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0407897830009460e-01" rms="8.7711172103881836e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="7.5557953119277954e-01" cType="1" res="2.8277033567428589e-01" rms="8.0194177627563477e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.1717617101967335e-03" rms="8.0206975936889648e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.3839775323867798e-01" rms="6.6437511444091797e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="12" Cut="1.1361610144376755e-01" cType="1" res="2.0105240345001221e+00" rms="7.3234066963195801e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="9.1279929876327515e-01" cType="1" res="1.4786695241928101e+00" rms="7.3250946998596191e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.1291822493076324e-02" rms="6.9857087135314941e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.3881500363349915e-01" rms="7.2456712722778320e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0731774568557739e+00" rms="5.3446125984191895e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="87">
+      <Node pos="s" depth="0" NCoef="0" IVar="10" Cut="8.6371469497680664e-01" cType="1" res="1.2231471482664347e-03" rms="7.8867435455322266e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="13" Cut="1.8666666030883789e+01" cType="1" res="-7.1849480271339417e-02" rms="7.9099502563476562e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="12" Cut="2.2946278750896454e-01" cType="1" res="7.1207515895366669e-02" rms="7.7930226325988770e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.1713183522224426e-02" rms="7.6793832778930664e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7396785318851471e-02" rms="7.8458666801452637e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="3" Cut="-1.0156060457229614e+00" cType="1" res="-7.4922043085098267e-01" rms="8.4086570739746094e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0953208804130554e-01" rms="8.5462112426757812e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.7420712113380432e-01" rms="8.3511066436767578e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="12" Cut="1.2483479082584381e-01" cType="1" res="1.3558992147445679e+00" rms="7.3123540878295898e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="9.1472005844116211e-01" cType="1" res="3.6838495731353760e-01" rms="7.2216238975524902e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.8412719070911407e-02" rms="6.9267435073852539e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7396911978721619e-01" rms="7.4224991798400879e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="8.7871444225311279e-01" cType="1" res="5.7495455741882324e+00" rms="5.9744973182678223e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.1056865453720093e-01" rms="6.2150073051452637e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.8861945867538452e+00" rms="3.7488229274749756e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="88">
+      <Node pos="s" depth="0" NCoef="0" IVar="10" Cut="9.1002750396728516e-01" cType="1" res="1.1864405870437622e-01" rms="7.8946046829223633e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="12" Cut="1.3884626328945160e-01" cType="1" res="6.8673498928546906e-02" rms="7.8972215652465820e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="3.8294784724712372e-02" cType="1" res="-7.9429268836975098e-01" rms="7.7741069793701172e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.0187031254172325e-02" rms="7.6922059059143066e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.9042921066284180e-01" rms="7.7918705940246582e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="8.5946917533874512e-01" cType="1" res="2.2685141861438751e-01" rms="7.9093761444091797e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1992097832262516e-02" rms="7.9088997840881348e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.4044975042343140e-01" rms="5.1561403274536133e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="12" Cut="8.1620469689369202e-02" cType="1" res="2.3112814426422119e+00" rms="7.4561438560485840e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="9.7926330566406250e-01" cType="1" res="9.1476249694824219e-01" rms="7.6947588920593262e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.5483417809009552e-02" rms="7.4545669555664062e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1089974641799927e+00" rms="7.6363883018493652e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="9.2749738693237305e-01" cType="1" res="5.5664029121398926e+00" rms="5.6591286659240723e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.9896368980407715e-01" rms="5.6343665122985840e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4270870685577393e+00" rms="3.7101597785949707e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="89">
+      <Node pos="s" depth="0" NCoef="0" IVar="3" Cut="2.1707625389099121e+00" cType="1" res="1.3947623968124390e-01" rms="7.9025125503540039e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="3" Cut="8.6466616392135620e-01" cType="1" res="1.9874094426631927e-01" rms="7.9020853042602539e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="3.8917224854230881e-02" cType="1" res="-8.7337829172611237e-03" rms="7.8951101303100586e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.3056543916463852e-02" rms="7.8449254035949707e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1777043342590332e-01" rms="8.0990056991577148e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="2.2105653584003448e-01" cType="1" res="8.1743341684341431e-01" rms="7.8905258178710938e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.0975208394229412e-03" rms="7.7435665130615234e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.8460600078105927e-01" rms="7.9475932121276855e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="11" Cut="2.2971667349338531e-01" cType="1" res="-1.6724244356155396e+00" rms="7.6984319686889648e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="4" Cut="5.3975883483886719e+01" cType="1" res="-1.0353430509567261e+00" rms="7.6988754272460938e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.2601553499698639e-02" rms="6.8920836448669434e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.0729600787162781e-01" rms="8.0457696914672852e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="3.5063779354095459e-01" cType="1" res="-4.3251895904541016e+00" rms="7.1070551872253418e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.0233180522918701e-01" rms="6.2192735671997070e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.2121660262346268e-01" rms="7.7020478248596191e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="90">
+      <Node pos="s" depth="0" NCoef="0" IVar="1" Cut="2.2994827270507812e+02" cType="1" res="1.0329359769821167e-01" rms="7.9167642593383789e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="1" Cut="3.2239425659179688e+01" cType="1" res="6.5287448465824127e-02" rms="7.8829736709594727e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="4" Cut="2.9691617965698242e+01" cType="1" res="-1.1098467111587524e+00" rms="6.5540947914123535e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.1514261662960052e-02" rms="6.7059078216552734e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.0893844366073608e-01" rms="5.7653293609619141e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="3" Cut="2.1713562011718750e+00" cType="1" res="1.6149239242076874e-01" rms="7.9743084907531738e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.5758238732814789e-02" rms="7.9675502777099609e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.3291899263858795e-01" rms="7.9476213455200195e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="2" Cut="1.6789110183715820e+01" cType="1" res="2.7896926403045654e+00" rms="9.6484699249267578e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="4" Cut="2.9521899414062500e+02" cType="1" res="-4.9508067965507507e-01" rms="9.7130403518676758e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.6389058232307434e-01" rms="9.3810119628906250e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.1963687539100647e-01" rms="9.5836858749389648e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="2.8040335083007812e+02" cType="1" res="4.4673995971679688e+00" rms="9.1721773147583008e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.3821750879287720e-01" rms="9.3413896560668945e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.7627561092376709e+00" rms="8.6243581771850586e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="91">
+      <Node pos="s" depth="0" NCoef="0" IVar="10" Cut="7.7043610811233521e-01" cType="1" res="5.1321908831596375e-02" rms="7.9101204872131348e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="12" Cut="2.7535533905029297e-01" cType="1" res="-9.7179047763347626e-02" rms="8.0203905105590820e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="8.7776362895965576e-02" cType="1" res="-5.1695758104324341e-01" rms="7.9761929512023926e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.3074322044849396e-01" rms="7.8614721298217773e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.9526193886995316e-02" rms="8.2325372695922852e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="7.3393225669860840e-01" cType="1" res="2.0919261872768402e-01" rms="8.0386686325073242e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.2533882185816765e-03" rms="8.0302619934082031e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3233804702758789e+00" rms="4.3263769149780273e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="12" Cut="2.3605065047740936e-01" cType="1" res="7.9387092590332031e-01" rms="7.2886600494384766e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="12" Cut="1.7975242435932159e-01" cType="1" res="5.4984420537948608e-01" rms="7.2409806251525879e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.0300461221486330e-03" rms="7.2052640914916992e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.4381008744239807e-01" rms="7.1770238876342773e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="2.4846899509429932e-01" cType="1" res="7.7950630187988281e+00" rms="4.7196407318115234e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.4053927659988403e-01" rms="4.8289594650268555e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.0513024330139160e+00" rms="4.1397428512573242e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="92">
+      <Node pos="s" depth="0" NCoef="0" IVar="10" Cut="2.3349983990192413e-01" cType="1" res="6.7185670137405396e-02" rms="7.9182114601135254e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="3" Cut="-2.1713323593139648e+00" cType="1" res="1.3415817022323608e+00" rms="8.3213062286376953e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="6.0496448516845703e+01" cType="1" res="-2.4758620262145996e+00" rms="8.2217483520507812e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.4172804802656174e-02" rms="8.0257511138916016e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.3619465827941895e-01" rms="7.1125154495239258e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="3" Cut="1.9646580219268799e+00" cType="1" res="1.7244411706924438e+00" rms="8.2341470718383789e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.4868943691253662e-01" rms="8.2010488510131836e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.9798333942890167e-01" rms="7.7453718185424805e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="15" Cut="2.9731996059417725e+00" cType="1" res="-9.1133397072553635e-03" rms="7.8868937492370605e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="7.2033452987670898e-01" cType="1" res="5.6198481470346451e-02" rms="7.8958525657653809e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.5231802612543106e-02" rms="8.0426301956176758e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.3883595168590546e-02" rms="7.3861575126647949e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="1.8383072689175606e-02" cType="1" res="-1.2042261362075806e+00" rms="7.6229529380798340e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.1097512245178223e-02" rms="7.3557863235473633e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.7607518434524536e-01" rms="7.7445554733276367e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="93">
+      <Node pos="s" depth="0" NCoef="0" IVar="3" Cut="-1.0286499261856079e+00" cType="1" res="1.9658522307872772e-01" rms="7.9432291984558105e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="3" Cut="-1.8123655319213867e+00" cType="1" res="7.4309611320495605e-01" rms="7.9261302947998047e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="-2.3440012931823730e+00" cType="1" res="-3.7870785593986511e-01" rms="7.8682475090026855e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.6829494237899780e-01" rms="7.3710098266601562e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.9178516939282417e-02" rms="7.8324584960937500e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="3" Cut="-1.3646973371505737e+00" cType="1" res="1.3421106338500977e+00" rms="7.8918261528015137e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.0259737372398376e-01" rms="7.6835465431213379e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.5753519982099533e-02" rms="8.0189208984375000e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="3" Cut="9.3034291267395020e-01" cType="1" res="2.5496723130345345e-02" rms="7.9408478736877441e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="6.9430552423000336e-02" cType="1" res="-2.5705781579017639e-01" rms="7.9024009704589844e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.2936914861202240e-02" rms="7.8286728858947754e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.3260526657104492e-02" rms="8.2629222869873047e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="3" Cut="1.9098067283630371e+00" cType="1" res="5.6951963901519775e-01" rms="7.9862484931945801e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1113765090703964e-01" rms="8.0243968963623047e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.1062952727079391e-02" rms="7.7993330955505371e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="94">
+      <Node pos="s" depth="0" NCoef="0" IVar="3" Cut="1.2569915056228638e+00" cType="1" res="1.9978375732898712e-01" rms="7.8998546600341797e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="5" Cut="3.5766880035400391e+01" cType="1" res="2.9160344973206520e-02" rms="7.8679594993591309e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="-8.3323252201080322e-01" cType="1" res="-6.2898389995098114e-02" rms="7.7609810829162598e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.8152247890830040e-02" rms="7.6866402626037598e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.6037057191133499e-02" rms="7.7913284301757812e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="3" Cut="-2.0408937931060791e+00" cType="1" res="1.3106617927551270e+00" rms="9.1333990097045898e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.3437554836273193e-01" rms="8.3665275573730469e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.6497998833656311e-01" rms="9.1187200546264648e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="3" Cut="1.9645031690597534e+00" cType="1" res="9.4306796789169312e-01" rms="7.9949522018432617e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="12" Cut="3.0350670218467712e-01" cType="1" res="1.6310899257659912e+00" rms="7.9122920036315918e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1973971128463745e-01" rms="7.7858080863952637e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.0294232964515686e-01" rms="8.0092058181762695e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="4" Cut="5.3909362792968750e+01" cType="1" res="-5.1368415355682373e-01" rms="7.9736375808715820e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0981301218271255e-01" rms="7.1973581314086914e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.3271402716636658e-01" rms="8.3571233749389648e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="95">
+      <Node pos="s" depth="0" NCoef="0" IVar="3" Cut="-2.1702399253845215e+00" cType="1" res="2.0111186802387238e-01" rms="7.9689054489135742e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="4" Cut="5.3217044830322266e+01" cType="1" res="-1.6698167324066162e+00" rms="7.9088892936706543e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="5.4627335071563721e-01" cType="1" res="1.8772917985916138e-01" rms="7.7084984779357910e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.9724020361900330e-01" rms="7.4616699218750000e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.2173045873641968e-01" rms="7.2636656761169434e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="5.3085509687662125e-02" cType="1" res="-3.1168553829193115e+00" rms="7.7592930793762207e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.7830859124660492e-01" rms="7.9367675781250000e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.1744940280914307e-01" rms="7.3596606254577637e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="3" Cut="-8.6436450481414795e-01" cType="1" res="2.6292267441749573e-01" rms="7.9633831977844238e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="12" Cut="2.9617941379547119e-01" cType="1" res="8.8843518495559692e-01" rms="7.9393239021301270e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.3136352896690369e-02" rms="7.8649396896362305e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.0586189627647400e-01" rms="7.9942588806152344e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="3" Cut="8.4592020511627197e-01" cType="1" res="5.0708267837762833e-02" rms="7.9603705406188965e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.7570885866880417e-02" rms="7.9055008888244629e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.3727475702762604e-02" rms="8.0165462493896484e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="96">
+      <Node pos="s" depth="0" NCoef="0" IVar="2" Cut="2.6549104690551758e+01" cType="1" res="1.1962214857339859e-01" rms="7.9401841163635254e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="16" Cut="6.2233197689056396e-01" cType="1" res="2.1953260898590088e-01" rms="7.9122095108032227e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="14" Cut="4.7619048506021500e-02" cType="1" res="2.2877380251884460e-02" rms="7.8664402961730957e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.1221174299716949e-01" rms="8.2398595809936523e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.4511395022273064e-02" rms="7.8338198661804199e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="15" Cut="3.0696787834167480e+00" cType="1" res="6.3037663698196411e-01" rms="7.9913840293884277e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.7142698466777802e-02" rms="8.0028619766235352e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.3268242776393890e-01" rms="7.6360173225402832e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="10" Cut="7.2567474842071533e-01" cType="1" res="-9.4117987155914307e-01" rms="8.1562070846557617e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="1.4840956926345825e+00" cType="1" res="-1.3220809698104858e+00" rms="8.2651853561401367e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.5044816732406616e-01" rms="8.1851320266723633e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.3230810463428497e-02" rms="8.4376411437988281e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="8.0832326412200928e-01" cType="1" res="6.2537449598312378e-01" rms="7.4908499717712402e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.8573356866836548e-02" rms="7.5316243171691895e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.2708478569984436e-01" rms="7.2271232604980469e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="97">
+      <Node pos="s" depth="0" NCoef="0" IVar="14" Cut="4.7619048506021500e-02" cType="1" res="9.8413288593292236e-02" rms="7.9768624305725098e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="1" Cut="3.6180213928222656e+01" cType="1" res="1.3184287548065186e+00" rms="8.1050786972045898e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="12" Cut="4.8321393132209778e-01" cType="1" res="-6.0428434610366821e-01" rms="7.1359672546386719e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.0926143229007721e-01" rms="6.9366245269775391e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.6601979136466980e-01" rms="6.9101319313049316e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="15" Cut="4.0769121050834656e-01" cType="1" res="1.8352344036102295e+00" rms="8.2705287933349609e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.0709633231163025e-01" rms="8.2146682739257812e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.2539253532886505e-01" rms="8.6239271163940430e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="3" Cut="7.9970628023147583e-01" cType="1" res="3.4969683736562729e-02" rms="7.9650287628173828e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="-7.2390615940093994e-01" cType="1" res="-1.3330483436584473e-01" rms="7.9292364120483398e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1982114985585213e-02" rms="8.0105247497558594e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.2084344923496246e-02" rms="7.8515214920043945e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="5.0312173366546631e-01" cType="1" res="4.3925899267196655e-01" rms="8.0359811782836914e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.8632968887686729e-02" rms="8.0024232864379883e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.5788259506225586e-01" rms="8.1779899597167969e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="98">
+      <Node pos="s" depth="0" NCoef="0" IVar="15" Cut="3.3346297740936279e+00" cType="1" res="4.9450337886810303e-02" rms="7.9193034172058105e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="10" Cut="7.6864445209503174e-01" cType="1" res="9.9516011774539948e-02" rms="7.9265727996826172e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="3.8917224854230881e-02" cType="1" res="-1.8504552543163300e-02" rms="8.0171556472778320e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.4295577555894852e-02" rms="7.9623637199401855e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.5415842235088348e-02" rms="8.2366533279418945e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="2.1244558691978455e-01" cType="1" res="7.4772852659225464e-01" rms="7.3757462501525879e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.8831332921981812e-02" rms="7.3563942909240723e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.8087229728698730e-01" rms="6.6111545562744141e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="13" Cut="1.4000000000000000e+01" cType="1" res="-1.6195192337036133e+00" rms="7.4837455749511719e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="13" Cut="1.3476190567016602e+01" cType="1" res="-1.0705730915069580e+00" rms="7.3272809982299805e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.0357355251908302e-02" rms="7.0284070968627930e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.2484154701232910e-01" rms="7.6592497825622559e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="2" Cut="1.8450273513793945e+01" cType="1" res="-2.0838792324066162e+00" rms="7.5826263427734375e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.1602717489004135e-02" rms="7.3041844367980957e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.4454449415206909e-01" rms="7.5795516967773438e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="99">
+      <Node pos="s" depth="0" NCoef="0" IVar="6" Cut="1.4227850437164307e+00" cType="1" res="1.3804848492145538e-01" rms="7.8981366157531738e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="7" Cut="-8.3285049438476562e+01" cType="1" res="2.1599058806896210e-01" rms="7.8471260070800781e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="12" Cut="4.1303300857543945e-01" cType="1" res="6.2363695353269577e-02" rms="7.7032098770141602e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.8779664784669876e-02" rms="7.5995001792907715e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.8199399411678314e-02" rms="7.9887285232543945e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="9.7465240478515625e+01" cType="1" res="7.6922386884689331e-01" rms="8.3213891983032227e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.7821094989776611e-02" rms="8.0890588760375977e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.9173414707183838e-01" rms="9.3999967575073242e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="5" Cut="3.6317523956298828e+01" cType="1" res="-8.9276796579360962e-01" rms="8.4770221710205078e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="-1.9397847652435303e+00" cType="1" res="-1.1927689313888550e+00" rms="8.3183860778808594e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.0078197717666626e-01" rms="7.9356017112731934e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.6796913743019104e-01" rms="8.3158435821533203e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="2.7697354555130005e-01" cType="1" res="9.1784435510635376e-01" rms="9.1716289520263672e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.3042747974395752e-02" rms="8.8236446380615234e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7257088422775269e+00" rms="9.1090869903564453e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="100">
+      <Node pos="s" depth="0" NCoef="0" IVar="11" Cut="5.8952289819717407e-01" cType="1" res="1.2984652817249298e-01" rms="7.9219088554382324e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="12" Cut="1.3884626328945160e-01" cType="1" res="1.1441026628017426e-01" rms="7.9174051284790039e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="4.5847065746784210e-02" cType="1" res="-5.7516884803771973e-01" rms="7.6919097900390625e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.2867434322834015e-01" rms="7.5179839134216309e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.7389696165919304e-03" rms="8.1567659378051758e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="8.2934361696243286e-01" cType="1" res="2.5470769405364990e-01" rms="7.9551868438720703e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.2262754440307617e-03" rms="7.9575734138488770e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.5180538296699524e-01" rms="7.2544217109680176e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2194712162017822e+00" rms="7.3797636032104492e+00" purity="1.0000000000000000e+00" nType="-99"/>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="101">
+      <Node pos="s" depth="0" NCoef="0" IVar="10" Cut="9.0930932760238647e-01" cType="1" res="1.1664220690727234e-01" rms="7.8524041175842285e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="11" Cut="3.0492568016052246e-01" cType="1" res="7.6047740876674652e-02" rms="7.8581037521362305e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="5.6788080930709839e-01" cType="1" res="2.0109489560127258e-02" rms="7.8346848487854004e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.2566837519407272e-02" rms="8.0424261093139648e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3462318107485771e-02" rms="7.6490015983581543e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="4" Cut="1.0674765014648438e+02" cType="1" res="1.1735030412673950e+00" rms="8.2276496887207031e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.5373622775077820e-01" rms="8.0293893814086914e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.2334944605827332e-01" rms="8.5962457656860352e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="12" Cut="9.1508500277996063e-02" cType="1" res="1.9821686744689941e+00" rms="7.3477387428283691e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="13" Cut="2.0000000000000000e+01" cType="1" res="8.4283971786499023e-01" rms="7.2113265991210938e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3958398997783661e-01" rms="6.9190177917480469e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.1288357973098755e-01" rms="8.3100814819335938e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2965973615646362e+00" rms="4.9265251159667969e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="102">
+      <Node pos="s" depth="0" NCoef="0" IVar="8" Cut="-9.4267158508300781e+01" cType="1" res="1.8321412801742554e-01" rms="7.8605136871337891e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="9" Cut="2.5912520289421082e-01" cType="1" res="-9.5235491171479225e-03" rms="7.6537036895751953e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="7.2532546520233154e-01" cType="1" res="-3.8601353764533997e-02" rms="7.6438069343566895e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.7294702380895615e-02" rms="7.7815394401550293e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.1299372911453247e-02" rms="7.2712912559509277e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="4" Cut="6.8417991638183594e+01" cType="1" res="2.9762101173400879e+00" rms="8.0698881149291992e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.7709985971450806e-01" rms="7.5037517547607422e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0106354206800461e-01" rms="9.0211868286132812e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="13" Cut="2.0142856597900391e+01" cType="1" res="6.8368166685104370e-01" rms="8.3529644012451172e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="6" Cut="1.6080056428909302e+00" cType="1" res="8.6869663000106812e-01" rms="8.2858686447143555e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.5840883553028107e-01" rms="8.2463607788085938e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.8489004373550415e-02" rms="8.3738079071044922e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="3" Cut="-1.0176110267639160e+00" cType="1" res="-9.8145318031311035e-01" rms="8.7600641250610352e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.0220241546630859e-01" rms="8.7093763351440430e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.9038062691688538e-01" rms="8.5793685913085938e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="103">
+      <Node pos="s" depth="0" NCoef="0" IVar="8" Cut="-9.4267524719238281e+01" cType="1" res="1.3490243256092072e-01" rms="7.8728003501892090e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="10" Cut="7.2912842035293579e-01" cType="1" res="-1.5096827410161495e-02" rms="7.6475667953491211e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="12" Cut="3.2124790549278259e-01" cType="1" res="-2.4964314699172974e-01" rms="7.8091206550598145e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.4657956361770630e-01" rms="7.7710247039794922e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.8109231963753700e-02" rms="7.7929143905639648e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="2.6512989401817322e-01" cType="1" res="5.9409940242767334e-01" rms="7.1753387451171875e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7025651410222054e-02" rms="7.1218304634094238e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0024478435516357e+00" rms="5.4999651908874512e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="2" Cut="2.3328397750854492e+01" cType="1" res="5.3295534849166870e-01" rms="8.4284868240356445e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="6" Cut="7.9225605726242065e-01" cType="1" res="8.0635303258895874e-01" rms="8.3824777603149414e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.2753697633743286e-01" rms="8.2888126373291016e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.8513213843107224e-02" rms="8.4090776443481445e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="8" Cut="1.8869383633136749e-01" cType="1" res="-5.9790521860122681e-01" rms="8.5235309600830078e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.0025136917829514e-02" rms="8.5159940719604492e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.1300194263458252e-01" rms="7.9088253974914551e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="104">
+      <Node pos="s" depth="0" NCoef="0" IVar="12" Cut="6.9265711307525635e-01" cType="1" res="5.9482123702764511e-02" rms="7.8381977081298828e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="3" Cut="-1.9428983926773071e+00" cType="1" res="2.1513853222131729e-02" rms="7.8303365707397461e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="7.4256072998046875e+01" cType="1" res="-1.0556793212890625e+00" rms="7.6863460540771484e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.3429559320211411e-02" rms="7.3024563789367676e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.4149464368820190e-01" rms="8.0779771804809570e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="3" Cut="-1.1152983903884888e+00" cType="1" res="9.5315799117088318e-02" rms="7.8346858024597168e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1431558430194855e-01" rms="7.8046350479125977e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.5965511798858643e-02" rms="7.8306584358215332e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="10" Cut="2.7127692103385925e-01" cType="1" res="2.4895746707916260e+00" rms="7.9575943946838379e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="12" Cut="7.5865113735198975e-01" cType="1" res="1.7310980558395386e+00" rms="8.0104227066040039e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.1130885481834412e-02" rms="8.2626800537109375e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.1077139973640442e-01" rms="7.5802502632141113e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.0223586559295654e-01" rms="7.3050060272216797e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="105">
+      <Node pos="s" depth="0" NCoef="0" IVar="2" Cut="2.9346876144409180e+01" cType="1" res="1.1773146688938141e-01" rms="7.8700499534606934e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="2" Cut="1.1862621307373047e+01" cType="1" res="1.7305231094360352e-01" rms="7.8498163223266602e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="16" Cut="2.3070805072784424e+00" cType="1" res="1.1706521511077881e+00" rms="7.5552477836608887e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2114319205284119e-01" rms="7.5728278160095215e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.2533308267593384e-01" rms="7.0037770271301270e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="4.6177141368389130e-02" cType="1" res="1.2006376683712006e-01" rms="7.8616142272949219e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.2787825763225555e-01" rms="7.6012220382690430e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.5230660103261471e-03" rms="7.8638777732849121e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="6" Cut="7.6676714420318604e-01" cType="1" res="-1.3892580270767212e+00" rms="8.2612247467041016e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="1.1945555114746094e+02" cType="1" res="-9.7315430641174316e-01" rms="8.2180824279785156e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.0030555129051208e-01" rms="8.0217924118041992e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.2084607481956482e-01" rms="9.3072137832641602e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="8" Cut="1.0173229873180389e-01" cType="1" res="-3.4489712715148926e+00" rms="8.1650257110595703e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.9213625192642212e-01" rms="8.7123537063598633e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.2757863998413086e-01" rms="7.4895739555358887e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="106">
+      <Node pos="s" depth="0" NCoef="0" IVar="12" Cut="7.8501141071319580e-01" cType="1" res="7.3820263147354126e-02" rms="7.8526968955993652e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="12" Cut="2.2377105057239532e-01" cType="1" res="5.5895745754241943e-02" rms="7.8482761383056641e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="8.4247177839279175e-01" cType="1" res="-2.8848481178283691e-01" rms="7.7405524253845215e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.6866006255149841e-02" rms="7.8098073005676270e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.1548540592193604e-02" rms="7.3636407852172852e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="7.7740329504013062e-01" cType="1" res="2.6681452989578247e-01" rms="7.9061245918273926e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.5397581271827221e-02" rms="7.9015669822692871e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0121581554412842e+00" rms="5.1393680572509766e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="2" Cut="1.9456218719482422e+01" cType="1" res="4.2660484313964844e+00" rms="7.7620215415954590e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.9967069625854492e-01" rms="7.8299798965454102e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4799098968505859e+00" rms="6.9846334457397461e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="107">
+      <Node pos="s" depth="0" NCoef="0" IVar="12" Cut="6.9423133134841919e-01" cType="1" res="6.9781862199306488e-02" rms="7.8431830406188965e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="11" Cut="4.9783223867416382e-01" cType="1" res="3.4675292670726776e-02" rms="7.8367004394531250e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="5.9508281946182251e-01" cType="1" res="1.6578759998083115e-02" rms="7.8308200836181641e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.9737109094858170e-02" rms="8.0290222167968750e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.5450184233486652e-02" rms="7.6134948730468750e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="1.2414460629224777e-01" cType="1" res="2.5186154842376709e+00" rms="8.2367639541625977e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.7133266031742096e-02" rms="7.9075298309326172e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.2477725744247437e-01" rms="8.2494325637817383e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="10" Cut="2.3182508349418640e-01" cType="1" res="2.2509443759918213e+00" rms="7.9370646476745605e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="12" Cut="8.2773947715759277e-01" cType="1" res="7.6434445381164551e-01" rms="7.8825693130493164e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.8790225535631180e-02" rms="7.4878110885620117e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.1042960882186890e-01" rms="8.1284656524658203e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="2.4359416216611862e-02" cType="1" res="3.9600286483764648e+00" rms="7.6502566337585449e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.6204549670219421e-01" rms="7.8978214263916016e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3923792839050293e+00" rms="5.8354835510253906e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="108">
+      <Node pos="s" depth="0" NCoef="0" IVar="2" Cut="1.5536841392517090e+01" cType="1" res="7.9905107617378235e-02" rms="7.8087658882141113e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="10" Cut="8.8843935728073120e-01" cType="1" res="6.0358834266662598e-01" rms="7.6941871643066406e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="2" Cut="1.0707868576049805e+01" cType="1" res="5.2087104320526123e-01" rms="7.7077021598815918e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.4271602928638458e-01" rms="7.4047179222106934e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.4770265221595764e-02" rms="7.7259092330932617e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="5.1619678497314453e+01" cType="1" res="2.7421462535858154e+00" rms="7.0048909187316895e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.1090043932199478e-02" rms="6.0965609550476074e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.4938145875930786e-01" rms="7.0250387191772461e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="12" Cut="2.7706283330917358e-01" cType="1" res="-7.7042646706104279e-02" rms="7.8359661102294922e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="5" Cut="8.3552085876464844e+01" cType="1" res="-3.3484733104705811e-01" rms="7.7155179977416992e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.6722566485404968e-02" rms="7.7045454978942871e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.1176253557205200e+00" rms="7.7578063011169434e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="7.2449040412902832e-01" cType="1" res="1.8387669324874878e-01" rms="7.9475021362304688e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.3774851150810719e-03" rms="7.9389090538024902e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2066805362701416e+00" rms="4.5957837104797363e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="109">
+      <Node pos="s" depth="0" NCoef="0" IVar="2" Cut="1.5141632080078125e+01" cType="1" res="1.1269043385982513e-01" rms="7.8041119575500488e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="2" Cut="1.0254918098449707e+01" cType="1" res="6.6965281963348389e-01" rms="7.6249012947082520e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="2" Cut="7.9507160186767578e+00" cType="1" res="2.0440397262573242e+00" rms="6.9314279556274414e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.5865488052368164e-01" rms="7.4604401588439941e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.8496902287006378e-01" rms="6.7653684616088867e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="1.8146502971649170e-01" cType="1" res="5.3289979696273804e-01" rms="7.6770358085632324e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.2295402139425278e-02" rms="7.6709713935852051e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.5169009864330292e-02" rms="7.6671195030212402e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="10" Cut="9.3912804126739502e-01" cType="1" res="-2.5082822889089584e-02" rms="7.8417105674743652e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="12" Cut="9.1370388865470886e-02" cType="1" res="-5.0101749598979950e-02" rms="7.8352351188659668e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.7115458846092224e-01" rms="7.6483592987060547e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.0797845199704170e-02" rms="7.8422474861145020e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="5.4952073842287064e-02" cType="1" res="2.3964135646820068e+00" rms="8.0866327285766602e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.1836473047733307e-01" rms="8.0577936172485352e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2076953649520874e+00" rms="5.7961835861206055e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="110">
+      <Node pos="s" depth="0" NCoef="0" IVar="12" Cut="5.0910294055938721e-01" cType="1" res="1.9477251172065735e-01" rms="7.8501634597778320e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="1" Cut="1.7402874755859375e+02" cType="1" res="1.2020116299390793e-01" rms="7.8193397521972656e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="3.8231967926025391e+01" cType="1" res="7.0249632000923157e-02" rms="7.7524676322937012e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.8397622108459473e-02" rms="6.7930760383605957e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.8206620588898659e-02" rms="7.9390811920166016e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="2" Cut="1.2679832458496094e+01" cType="1" res="1.5190838575363159e+00" rms="9.3956003189086914e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.8286747932434082e+00" rms="6.9074850082397461e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.3475103974342346e-01" rms="9.4534063339233398e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="10" Cut="4.7570127248764038e-01" cType="1" res="8.9267110824584961e-01" rms="8.0997667312622070e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="1.8005514144897461e-01" cType="1" res="4.6438449621200562e-01" rms="8.0529642105102539e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.2835033237934113e-02" rms="8.0087337493896484e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.6705658435821533e-01" rms="7.4717082977294922e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="4.9516960978507996e-01" cType="1" res="6.3900351524353027e+00" rms="6.5371541976928711e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.2492407560348511e-01" rms="7.3075661659240723e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.0920028686523438e+00" rms="2.0024790763854980e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="111">
+      <Node pos="s" depth="0" NCoef="0" IVar="15" Cut="1.2142689228057861e+00" cType="1" res="1.9386248290538788e-01" rms="7.8701815605163574e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="1" Cut="5.6314559936523438e+01" cType="1" res="4.0622520446777344e-01" rms="7.9749612808227539e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="2.8197008132934570e+01" cType="1" res="8.3732277154922485e-02" rms="7.3719859123229980e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.8305288553237915e-01" rms="5.4752793312072754e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2734905816614628e-02" rms="7.3992214202880859e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="8.7434309720993042e-01" cType="1" res="7.3522186279296875e-01" rms="8.5338220596313477e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.8612993955612183e-02" rms="8.5379190444946289e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.8721933364868164e-01" rms="8.1042032241821289e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="10" Cut="8.4915459156036377e-01" cType="1" res="-2.0317965745925903e-01" rms="7.6546540260314941e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="3.4305292367935181e-01" cType="1" res="-3.2999271154403687e-01" rms="7.6836843490600586e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7808112502098083e-01" rms="8.2365999221801758e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.5914755463600159e-02" rms="7.6316652297973633e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="1.5734605491161346e-01" cType="1" res="8.5972535610198975e-01" rms="7.3210020065307617e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.3875090777873993e-02" rms="7.2864537239074707e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0851860046386719e+00" rms="4.5466456413269043e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="112">
+      <Node pos="s" depth="0" NCoef="0" IVar="12" Cut="8.3307754993438721e-01" cType="1" res="8.7335221469402313e-02" rms="7.8531794548034668e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="11" Cut="2.3580916225910187e-01" cType="1" res="7.2727881371974945e-02" rms="7.8475613594055176e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="6.5207117795944214e-01" cType="1" res="-1.1405983939766884e-02" rms="7.8135781288146973e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.8410428464412689e-02" rms="8.0013837814331055e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.2391037791967392e-02" rms="7.5197434425354004e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="3" Cut="1.9428111314773560e+00" cType="1" res="9.4679594039916992e-01" rms="8.1410036087036133e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7126396298408508e-01" rms="8.1287689208984375e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.4574834108352661e-01" rms="7.7921671867370605e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0156557559967041e+00" rms="8.0385351181030273e+00" purity="1.0000000000000000e+00" nType="-99"/>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="113">
+      <Node pos="s" depth="0" NCoef="0" IVar="1" Cut="3.9827429199218750e+02" cType="1" res="7.1053721010684967e-02" rms="7.8217320442199707e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="9" Cut="5.0431770086288452e-01" cType="1" res="5.6325003504753113e-02" rms="7.8151898384094238e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="4.0230651855468750e+01" cType="1" res="2.6872662827372551e-02" rms="7.8062462806701660e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.6435828804969788e-02" rms="6.8296365737915039e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.5763297714293003e-03" rms="8.0375652313232422e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="7" Cut="3.5360752105712891e+01" cType="1" res="2.8307638168334961e+00" rms="8.1522312164306641e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.3718622922897339e-01" rms="7.4501223564147949e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.5081526711583138e-02" rms="8.8412981033325195e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3903497695922852e+01" rms="7.6342024803161621e+00" purity="1.0000000000000000e+00" nType="-99"/>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="114">
+      <Node pos="s" depth="0" NCoef="0" IVar="5" Cut="4.7366142272949219e+01" cType="1" res="1.1454947292804718e-01" rms="7.8258638381958008e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="7" Cut="4.8513450622558594e+01" cType="1" res="7.3595792055130005e-02" rms="7.7797365188598633e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="12" Cut="2.2683128714561462e-01" cType="1" res="8.8442042469978333e-02" rms="7.7741794586181641e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.9804382026195526e-02" rms="7.6399097442626953e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.3247702047228813e-02" rms="7.8508129119873047e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.8787685632705688e-01" rms="8.2538166046142578e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="10" Cut="5.3063362836837769e-01" cType="1" res="1.5191736221313477e+00" rms="9.1598529815673828e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="2" Cut="1.6044164657592773e+01" cType="1" res="3.5176863670349121e+00" rms="8.7175140380859375e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.1790474057197571e-01" rms="9.0840978622436523e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1627538204193115e+00" rms="7.9359278678894043e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="8.4561640024185181e-01" cType="1" res="5.1192319393157959e-01" rms="9.2119979858398438e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.4424759149551392e-01" rms="9.2692623138427734e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.6508350372314453e-01" rms="8.5186071395874023e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="115">
+      <Node pos="s" depth="0" NCoef="0" IVar="5" Cut="4.7508998870849609e+01" cType="1" res="9.0488679707050323e-02" rms="7.8330254554748535e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="5" Cut="5.0128579139709473e+00" cType="1" res="4.9685917794704437e-02" rms="7.7787032127380371e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="2.9470991134643555e+01" cType="1" res="-7.2452074289321899e-01" rms="7.3320322036743164e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.3673486113548279e-01" rms="5.8846311569213867e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.2433850020170212e-02" rms="7.4558749198913574e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="5.9660321474075317e-01" cType="1" res="1.2567572295665741e-01" rms="7.8170385360717773e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.7094194926321507e-03" rms="7.7917275428771973e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.4579335749149323e-01" rms="8.4952230453491211e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="3" Cut="-1.7022135257720947e+00" cType="1" res="1.4147611856460571e+00" rms="9.3312854766845703e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.5729013681411743e-01" rms="8.6956501007080078e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          <Node pos="r" depth="2" NCoef="0" IVar="7" Cut="7.5831001281738281e+01" cType="1" res="1.7968724966049194e+00" rms="9.2880830764770508e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.5800617337226868e-01" rms="9.1714067459106445e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.8088481426239014e-01" rms="9.8344011306762695e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="116">
+      <Node pos="s" depth="0" NCoef="0" IVar="2" Cut="1.2798708915710449e+01" cType="1" res="1.2352688610553741e-01" rms="7.8134942054748535e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="10" Cut="8.1839317083358765e-01" cType="1" res="1.0782815217971802e+00" rms="7.5735306739807129e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="12" Cut="2.0554903149604797e-01" cType="1" res="7.7001810073852539e-01" rms="7.6132116317749023e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.8241920769214630e-02" rms="7.6451187133789062e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4962103962898254e-01" rms="7.5630106925964355e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="5" Cut="2.5388578414916992e+01" cType="1" res="3.1153626441955566e+00" rms="6.9712553024291992e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.1497781574726105e-01" rms="6.6380395889282227e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0619418621063232e+00" rms="6.7929434776306152e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="1" Cut="3.3177752685546875e+02" cType="1" res="4.7113377600908279e-02" rms="7.8273506164550781e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="13" Cut="1.0190476417541504e+01" cType="1" res="3.3715289086103439e-02" rms="7.8166894912719727e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.6424614042043686e-02" rms="7.7304296493530273e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.7363982051610947e-02" rms="7.8350229263305664e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.9795186519622803e+00" rms="9.7999773025512695e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="117">
+      <Node pos="s" depth="0" NCoef="0" IVar="1" Cut="5.8677082061767578e+01" cType="1" res="1.6651454567909241e-01" rms="7.7920937538146973e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="4" Cut="5.6362007141113281e+01" cType="1" res="-8.2704864442348480e-02" rms="7.1604385375976562e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="5.5195400238037109e+01" cType="1" res="4.0458574891090393e-02" rms="7.1340680122375488e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.3957315832376480e-02" rms="7.0914115905761719e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.7652743458747864e-01" rms="7.4564743041992188e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="4" Cut="6.0199268341064453e+01" cType="1" res="-2.6661195755004883e+00" rms="7.2240185737609863e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.6119834184646606e-01" rms="7.2500653266906738e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.3513029813766479e-01" rms="5.0761032104492188e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="15" Cut="9.0944445133209229e-01" cType="1" res="4.0762132406234741e-01" rms="8.3508024215698242e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="-1.9428683519363403e+00" cType="1" res="7.2283279895782471e-01" rms="8.4649295806884766e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.7860428988933563e-01" rms="8.2521181106567383e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2528023123741150e-01" rms="8.4658136367797852e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="3" Cut="-1.2562434673309326e+00" cType="1" res="8.2043096423149109e-02" rms="8.2185773849487305e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4426875114440918e-01" rms="8.3228082656860352e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.0021078884601593e-02" rms="8.1858339309692383e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="118">
+      <Node pos="s" depth="0" NCoef="0" IVar="3" Cut="-2.1713559627532959e+00" cType="1" res="1.1491054296493530e-01" rms="7.8118090629577637e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="2" Cut="2.5068155288696289e+01" cType="1" res="-1.2836598157882690e+00" rms="7.3225479125976562e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="-2.2802922725677490e+00" cType="1" res="-8.0771857500076294e-01" rms="7.1801948547363281e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.5582373142242432e-01" rms="6.6573190689086914e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1199819855391979e-02" rms="7.4477686882019043e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="4.8013222217559814e-01" cType="1" res="-4.0744056701660156e+00" rms="7.5238780975341797e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.6974531412124634e-01" rms="7.4872403144836426e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.9471290111541748e-01" rms="7.1833410263061523e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="3" Cut="-1.3004801273345947e+00" cType="1" res="1.5808202326297760e-01" rms="7.8224477767944336e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="-2.0467822551727295e+00" cType="1" res="8.2016354799270630e-01" rms="7.8001303672790527e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.8275047838687897e-01" rms="7.9930090904235840e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4511594176292419e-01" rms="7.7377486228942871e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="3" Cut="2.2232871055603027e+00" cType="1" res="4.2835511267185211e-02" rms="7.8206005096435547e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.2812784239649773e-03" rms="7.8266477584838867e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.9136069715023041e-01" rms="7.4728879928588867e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="119">
+      <Node pos="s" depth="0" NCoef="0" IVar="11" Cut="1.5720610320568085e-01" cType="1" res="1.7019478976726532e-01" rms="7.7720007896423340e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="3" Cut="1.4853264093399048e+00" cType="1" res="6.7730195820331573e-02" rms="7.7086229324340820e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="2.4338226318359375e+02" cType="1" res="-4.3702293187379837e-02" rms="7.7007713317871094e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.6362063363194466e-02" rms="7.6732978820800781e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.9237415790557861e-01" rms="9.4762983322143555e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="6.8576776981353760e-01" cType="1" res="8.0471348762512207e-01" rms="7.7199621200561523e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.3783806711435318e-02" rms="7.9469738006591797e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.4602383375167847e-01" rms="7.1476917266845703e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="12" Cut="1.2433390319347382e-01" cType="1" res="6.7934656143188477e-01" rms="8.0602636337280273e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="4" Cut="1.1540872192382812e+02" cType="1" res="-1.3026012182235718e+00" rms="7.9252762794494629e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.4907319843769073e-01" rms="7.7845568656921387e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.0588467121124268e+00" rms="8.5679092407226562e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="4.7958770394325256e-01" cType="1" res="1.0863600969314575e+00" rms="8.0273685455322266e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2353117018938065e-01" rms="8.0132799148559570e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.0948663949966431e-01" rms="7.7034235000610352e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="120">
+      <Node pos="s" depth="0" NCoef="0" IVar="10" Cut="9.9333459138870239e-01" cType="1" res="7.0465348660945892e-02" rms="7.7859764099121094e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="13" Cut="1.9904762268066406e+01" cType="1" res="5.4864861071109772e-02" rms="7.7821068763732910e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="9.9825920104980469e+01" cType="1" res="1.5748274326324463e-01" rms="7.7115502357482910e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.2113980725407600e-02" rms="7.4915857315063477e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.8050302565097809e-01" rms="9.0092496871948242e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="5.3036528825759888e-01" cType="1" res="-5.9212791919708252e-01" rms="8.1834306716918945e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.7917245924472809e-02" rms="8.1611509323120117e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.4175276756286621e-01" rms="7.9993758201599121e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.8547574281692505e+00" rms="5.6794443130493164e+00" purity="1.0000000000000000e+00" nType="-99"/>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="121">
+      <Node pos="s" depth="0" NCoef="0" IVar="5" Cut="1.1514787673950195e+01" cType="1" res="-3.0168991535902023e-02" rms="7.7941637039184570e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="11" Cut="2.3580916225910187e-01" cType="1" res="-2.9137855768203735e-01" rms="7.3013277053833008e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="6.3606697320938110e-01" cType="1" res="-4.0772154927253723e-01" rms="7.2063441276550293e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.9928393959999084e-02" rms="7.4944415092468262e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.2618448175489902e-03" rms="6.6234264373779297e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="13" Cut="1.8666666030883789e+01" cType="1" res="5.6573718786239624e-01" rms="7.9137163162231445e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0643933713436127e-01" rms="7.8471212387084961e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.4312549829483032e-01" rms="7.0029144287109375e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="12" Cut="1.6065442562103271e-01" cType="1" res="1.9906878471374512e-01" rms="8.1954603195190430e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="-1.4704681634902954e+00" cType="1" res="-2.3572355508804321e-01" rms="7.9215135574340820e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.6975091397762299e-01" rms="7.7006812095642090e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.4676002860069275e-02" rms="7.9317393302917480e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="8.2934361696243286e-01" cType="1" res="3.9009693264961243e-01" rms="8.3057718276977539e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.5239029675722122e-02" rms="8.3099517822265625e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.6492720842361450e-01" rms="6.4722871780395508e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="122">
+      <Node pos="s" depth="0" NCoef="0" IVar="11" Cut="4.3231678009033203e-01" cType="1" res="6.3534125685691833e-02" rms="7.7771463394165039e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="6" Cut="1.4227850437164307e+00" cType="1" res="2.5115156546235085e-02" rms="7.7674803733825684e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="9.0955770015716553e-01" cType="1" res="9.2876471579074860e-02" rms="7.7165427207946777e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.7190580777823925e-03" rms="7.7198748588562012e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.0190006494522095e-01" rms="7.4172415733337402e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="6" Cut="3.8164591789245605e+00" cType="1" res="-8.5144865512847900e-01" rms="8.3491830825805664e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.1104864627122879e-01" rms="8.3120527267456055e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.0128276348114014e-01" rms="7.8518772125244141e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="15" Cut="8.1327015161514282e-01" cType="1" res="2.3934624195098877e+00" rms="8.0048780441284180e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="13" Cut="1.4000000000000000e+01" cType="1" res="3.0156209468841553e+00" rms="7.9715180397033691e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.5655699968338013e-01" rms="7.6237425804138184e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.2014068067073822e-01" rms="9.1776552200317383e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.8824803829193115e-01" rms="7.1560630798339844e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="123">
+      <Node pos="s" depth="0" NCoef="0" IVar="12" Cut="1.3884626328945160e-01" cType="1" res="1.6603349149227142e-01" rms="7.7613530158996582e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="13" Cut="1.9285715103149414e+01" cType="1" res="-3.2795780897140503e-01" rms="7.5815124511718750e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="17" Cut="5.3333334922790527e+00" cType="1" res="-1.7134217917919159e-01" rms="7.4977397918701172e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.3734224289655685e-02" rms="7.5128240585327148e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.5138235092163086e-01" rms="6.7566308975219727e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="8.9199614524841309e-01" cType="1" res="-1.3328204154968262e+00" rms="8.0260334014892578e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.1551510095596313e-01" rms="7.9591941833496094e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.7861184477806091e-02" rms="7.8845882415771484e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="5" Cut="9.5761718750000000e+00" cType="1" res="2.6461762189865112e-01" rms="7.7929992675781250e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="12" Cut="7.7363282442092896e-01" cType="1" res="-1.2962919473648071e-01" rms="7.2715234756469727e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.3208120614290237e-02" rms="7.2500953674316406e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.4231154918670654e-01" rms="7.9168281555175781e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="8.2934361696243286e-01" cType="1" res="5.2115428447723389e-01" rms="8.1040515899658203e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.5291276425123215e-02" rms="8.1169395446777344e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.1109613180160522e-01" rms="7.4731016159057617e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="124">
+      <Node pos="s" depth="0" NCoef="0" IVar="2" Cut="1.7194017410278320e+01" cType="1" res="1.3227951526641846e-01" rms="7.8019647598266602e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="13" Cut="2.8000000000000000e+01" cType="1" res="5.5950778722763062e-01" rms="7.6849040985107422e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="15" Cut="1.1826065778732300e+00" cType="1" res="5.4153251647949219e-01" rms="7.6798210144042969e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.6373789012432098e-02" rms="7.7262291908264160e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.3948784954845905e-03" rms="7.5786557197570801e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.0958297252655029e-01" rms="7.7625474929809570e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="11" Cut="1.5469631552696228e-01" cType="1" res="-1.0695104300975800e-01" rms="7.8566126823425293e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="13" Cut="2.4904762268066406e+01" cType="1" res="-2.4848902225494385e-01" rms="7.7779088020324707e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.7290181964635849e-02" rms="7.7240428924560547e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.1235107779502869e-01" rms="8.7839555740356445e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="3.9140376448631287e-01" cType="1" res="5.7668954133987427e-01" rms="8.1918039321899414e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.5126439779996872e-02" rms="8.1851778030395508e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.6976569890975952e-01" rms="7.0516505241394043e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="125">
+      <Node pos="s" depth="0" NCoef="0" IVar="7" Cut="7.5831001281738281e+01" cType="1" res="1.7166964709758759e-01" rms="7.7862386703491211e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="16" Cut="2.2327182292938232e+00" cType="1" res="1.8442420661449432e-01" rms="7.7815093994140625e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="12" Cut="3.1979635357856750e-01" cType="1" res="1.0498923808336258e-01" rms="7.7391958236694336e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.6213774457573891e-02" rms="7.6733765602111816e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.8808587938547134e-02" rms="7.8337140083312988e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="4" Cut="9.7521789550781250e+01" cType="1" res="1.1673859357833862e+00" rms="8.2240076065063477e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.2622804343700409e-01" rms="7.7382020950317383e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.3076948067173362e-04" rms="9.0715904235839844e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.9490470886230469e-01" rms="8.1389160156250000e+00" purity="1.0000000000000000e+00" nType="-99"/>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="126">
+      <Node pos="s" depth="0" NCoef="0" IVar="12" Cut="7.7755177021026611e-01" cType="1" res="1.3667912781238556e-01" rms="7.7722215652465820e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="3" Cut="1.9421856403350830e+00" cType="1" res="1.1826343089342117e-01" rms="7.7667474746704102e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="1.1151260137557983e+00" cType="1" res="1.8182434141635895e-01" rms="7.7717685699462891e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.1171071790158749e-02" rms="7.7670226097106934e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0848002135753632e-01" rms="7.7598481178283691e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="4" Cut="3.8279930114746094e+01" cType="1" res="-8.2118797302246094e-01" rms="7.6306529045104980e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.7977235913276672e-02" rms="6.5703473091125488e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.0242218673229218e-01" rms="7.8365421295166016e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="10" Cut="1.6125038266181946e-01" cType="1" res="3.8382360935211182e+00" rms="7.9834370613098145e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.9957198798656464e-02" rms="8.1923971176147461e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1531977653503418e+00" rms="6.5319252014160156e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="127">
+      <Node pos="s" depth="0" NCoef="0" IVar="10" Cut="5.9292322397232056e-01" cType="1" res="2.2606253623962402e-01" rms="7.7900161743164062e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="3" Cut="1.9423936605453491e+00" cType="1" res="-4.7584054991602898e-03" rms="8.0023021697998047e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="2.6806351542472839e-01" cType="1" res="1.1144684255123138e-01" rms="7.9963383674621582e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.3590747267007828e-02" rms="7.9768238067626953e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.6516631841659546e-01" rms="8.0648517608642578e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="5.0560140609741211e-01" cType="1" res="-1.2744182348251343e+00" rms="7.9573669433593750e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.0566528439521790e-01" rms="7.7963027954101562e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4643615484237671e-01" rms="8.0007562637329102e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="12" Cut="3.9766371250152588e-01" cType="1" res="4.7368615865707397e-01" rms="7.5478043556213379e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="12" Cut="2.6506486535072327e-01" cType="1" res="3.4452775120735168e-01" rms="7.5230383872985840e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.4447070471942425e-03" rms="7.4516959190368652e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2173467874526978e-01" rms="7.6504340171813965e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="4.0933248400688171e-01" cType="1" res="7.0579724311828613e+00" rms="5.6385564804077148e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.6470281481742859e-01" rms="6.7061800956726074e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.6608886718750000e+00" rms="3.1193583011627197e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="128">
+      <Node pos="s" depth="0" NCoef="0" IVar="16" Cut="5.4650813341140747e-01" cType="1" res="1.1801236867904663e-01" rms="7.7770318984985352e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="10" Cut="9.4649642705917358e-01" cType="1" res="-5.4891351610422134e-02" rms="7.7677087783813477e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="1.5720610320568085e-01" cType="1" res="-7.6203100383281708e-02" rms="7.7640080451965332e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.3750949203968048e-02" rms="7.6928520202636719e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.0374455749988556e-02" rms="8.0574474334716797e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="4.2755931615829468e-02" cType="1" res="3.1065130233764648e+00" rms="7.6682529449462891e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.8338859379291534e-02" rms="7.9905147552490234e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.9360795021057129e-01" rms="6.8580102920532227e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="12" Cut="5.8589679002761841e-01" cType="1" res="4.4618982076644897e-01" rms="7.7841415405273438e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="5.8182525634765625e-01" cType="1" res="3.7470531463623047e-01" rms="7.7731060981750488e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.1577248349785805e-02" rms="7.9376006126403809e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.9014003276824951e-02" rms="7.6301350593566895e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="2.7388468384742737e-02" cType="1" res="2.6875967979431152e+00" rms="7.7969031333923340e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.9137236475944519e-01" rms="8.0925645828247070e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.7709445953369141e-01" rms="7.0072846412658691e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="129">
+      <Node pos="s" depth="0" NCoef="0" IVar="2" Cut="1.8737958908081055e+01" cType="1" res="1.0217096656560898e-01" rms="7.8007574081420898e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="13" Cut="2.4000000000000000e+01" cType="1" res="3.6792406439781189e-01" rms="7.6851816177368164e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="4" Cut="2.5590356445312500e+02" cType="1" res="3.2913836836814880e-01" rms="7.6571068763732910e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.8575094416737556e-02" rms="7.6255474090576172e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.9297404289245605e-01" rms="1.0028349876403809e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="3" Cut="-6.8539506196975708e-01" cType="1" res="2.1826362609863281e+00" rms="8.7092809677124023e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0390443801879883e+00" rms="8.1947221755981445e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.0721682310104370e-01" rms="8.7123022079467773e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="6" Cut="3.4983296394348145e+00" cType="1" res="-1.4507856965065002e-01" rms="7.8987441062927246e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="16" Cut="1.0930162668228149e+00" cType="1" res="-1.2214755266904831e-01" rms="7.8893723487854004e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.0490129739046097e-02" rms="7.8438820838928223e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.1452316343784332e-02" rms="8.0489358901977539e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.3577364683151245e-01" rms="8.4818716049194336e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="130">
+      <Node pos="s" depth="0" NCoef="0" IVar="12" Cut="1.8470856547355652e-01" cType="1" res="7.2891399264335632e-02" rms="7.8438239097595215e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="6" Cut="-9.3420959472656250e+01" cType="1" res="-3.4297809004783630e-01" rms="7.6931276321411133e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="8.5166895389556885e-01" cType="1" res="-7.2170752286911011e-01" rms="7.3512549400329590e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.7230869829654694e-01" rms="7.3752503395080566e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.8175464123487473e-02" rms="7.1950521469116211e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="3" Cut="-1.1737656593322754e-01" cType="1" res="3.3373740315437317e-01" rms="8.2255687713623047e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2991416454315186e-01" rms="8.2951965332031250e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.0074890255928040e-02" rms="8.1269645690917969e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="10" Cut="8.1639552116394043e-01" cType="1" res="2.3486644029617310e-01" rms="7.8958153724670410e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="3.5868696868419647e-02" cType="1" res="1.7475990951061249e-01" rms="7.8917508125305176e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.6022967696189880e-03" rms="7.8769955635070801e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1384987086057663e-01" rms="7.9499335289001465e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="0" Cut="3.8542507171630859e+01" cType="1" res="7.0524606704711914e+00" rms="4.7679624557495117e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.3225028514862061e-01" rms="4.5641093254089355e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.9186891317367554e+00" rms="3.4202458858489990e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="131">
+      <Node pos="s" depth="0" NCoef="0" IVar="12" Cut="3.2397460937500000e-01" cType="1" res="1.6698998212814331e-01" rms="7.7777099609375000e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="10" Cut="7.3222035169601440e-01" cType="1" res="-4.7632865607738495e-04" rms="7.6792998313903809e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="7" Cut="8.1059551239013672e+00" cType="1" res="-2.9901024699211121e-01" rms="7.8869714736938477e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.0777726769447327e-01" rms="7.5929460525512695e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.0285921692848206e-02" rms="8.3912916183471680e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="2.5964212417602539e-01" cType="1" res="5.2974063158035278e-01" rms="7.2657256126403809e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.2444624453783035e-02" rms="7.2540426254272461e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.8831521272659302e-01" rms="5.9098215103149414e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="10" Cut="6.5361440181732178e-01" cType="1" res="4.4589155912399292e-01" rms="7.9310526847839355e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="1.0617101937532425e-01" cType="1" res="2.3407636582851410e-01" rms="7.9236159324645996e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.8811408206820488e-02" rms="7.8899164199829102e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4493614435195923e-01" rms="7.9577050209045410e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="3.3979493379592896e-01" cType="1" res="4.8404407501220703e+00" rms="6.7160186767578125e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.1031314134597778e-01" rms="6.7811551094055176e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.5056365728378296e+00" rms="4.8910694122314453e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="132">
+      <Node pos="s" depth="0" NCoef="0" IVar="3" Cut="5.7143682241439819e-01" cType="1" res="4.8760544508695602e-02" rms="7.7414722442626953e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="3" Cut="-1.2680222988128662e+00" cType="1" res="-1.1615737527608871e-01" rms="7.7187743186950684e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="5.3775537014007568e-01" cType="1" res="3.8398185372352600e-01" rms="7.6778898239135742e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.5508438944816589e-02" rms="7.9140300750732422e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.7545588612556458e-02" rms="7.4555597305297852e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="14" Cut="4.7619048506021500e-02" cType="1" res="-3.1484210491180420e-01" rms="7.7259759902954102e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.6831084489822388e-01" rms="8.0932636260986328e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.5849041342735291e-02" rms="7.7066764831542969e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="3" Cut="2.0517425537109375e+00" cType="1" res="3.5724878311157227e-01" rms="7.7743649482727051e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="12" Cut="3.2016837596893311e-01" cType="1" res="5.6271910667419434e-01" rms="7.7885198593139648e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.6314305365085602e-02" rms="7.6196398735046387e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.5087892115116119e-01" rms="8.0455436706542969e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="4.6734130382537842e-01" cType="1" res="-9.9190229177474976e-01" rms="7.5430026054382324e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.5232374072074890e-01" rms="7.6985244750976562e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.2999112308025360e-03" rms="7.1819200515747070e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="133">
+      <Node pos="s" depth="0" NCoef="0" IVar="1" Cut="1.7399476623535156e+02" cType="1" res="1.3594056665897369e-01" rms="7.7266836166381836e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="4" Cut="1.5706280517578125e+02" cType="1" res="8.5040830075740814e-02" rms="7.6640224456787109e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="1.4657496643066406e+02" cType="1" res="1.2057274580001831e-01" rms="7.6346554756164551e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.1257846169173717e-03" rms="7.6233744621276855e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.7866065502166748e-01" rms="8.3034324645996094e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="7" Cut="8.1059551239013672e+00" cType="1" res="-1.8062036037445068e+00" rms="8.8885526657104492e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.9645894765853882e-01" rms="8.4321918487548828e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.3370518684387207e-01" rms="9.6284828186035156e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="12" Cut="5.7832205295562744e-01" cType="1" res="1.5218904018402100e+00" rms="9.1635122299194336e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="2.6927236938476562e+02" cType="1" res="1.8354469537734985e+00" rms="9.1249895095825195e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.7996866703033447e-01" rms="8.7349481582641602e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.5901286900043488e-01" rms="9.9748611450195312e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.9139422178268433e-01" rms="8.7263822555541992e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="134">
+      <Node pos="s" depth="0" NCoef="0" IVar="1" Cut="3.9827429199218750e+02" cType="1" res="4.0663164108991623e-02" rms="7.7267565727233887e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="10" Cut="7.6768696308135986e-01" cType="1" res="2.7988484129309654e-02" rms="7.7188906669616699e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="2.1573220825195312e+02" cType="1" res="-8.7099507451057434e-02" rms="7.8180885314941406e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.4918751567602158e-02" rms="7.7769036293029785e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.9095466136932373e-01" rms="9.7242269515991211e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="2.2424219548702240e-01" cType="1" res="6.4390820264816284e-01" rms="7.1332149505615234e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.6479296386241913e-02" rms="7.1030902862548828e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.5615040063858032e-01" rms="6.2798705101013184e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.4064006805419922e+00" rms="9.0018024444580078e+00" purity="1.0000000000000000e+00" nType="-99"/>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="135">
+      <Node pos="s" depth="0" NCoef="0" IVar="2" Cut="2.4737827301025391e+01" cType="1" res="9.9665306508541107e-02" rms="7.7491474151611328e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="12" Cut="2.7706283330917358e-01" cType="1" res="1.8182118237018585e-01" rms="7.7221908569335938e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="7" Cut="-8.8004356384277344e+01" cType="1" res="-2.5757031515240669e-02" rms="7.6133561134338379e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.9733243882656097e-02" rms="7.2757534980773926e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.4754962921142578e-02" rms="8.2141656875610352e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="6.8703514337539673e-01" cType="1" res="4.0939119458198547e-01" rms="7.8334531784057617e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.8309382721781731e-02" rms="7.8447523117065430e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.1833728551864624e-01" rms="7.1473011970520020e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="13" Cut="1.7666666030883789e+01" cType="1" res="-4.1513860225677490e-01" rms="7.8965392112731934e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="17" Cut="4.1904764175415039e+00" cType="1" res="4.2303830385208130e-02" rms="7.8162860870361328e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.3981602638959885e-02" rms="7.8240060806274414e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.0994849801063538e-01" rms="7.0306673049926758e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="6.5992885828018188e-01" cType="1" res="-1.0910549163818359e+00" rms="7.9657092094421387e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.8562015295028687e-01" rms="7.8879218101501465e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.2825976610183716e-02" rms="7.9502291679382324e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="136">
+      <Node pos="s" depth="0" NCoef="0" IVar="2" Cut="2.5284914016723633e+01" cType="1" res="1.3931252062320709e-01" rms="7.7443122863769531e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="13" Cut="3.2000000000000000e+01" cType="1" res="2.2849324345588684e-01" rms="7.7127041816711426e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="13" Cut="1.4857142448425293e+01" cType="1" res="2.1752162277698517e-01" rms="7.7084879875183105e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.6356557607650757e-02" rms="7.5740218162536621e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.7589955627918243e-02" rms="7.8875403404235840e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7987922430038452e+00" rms="7.8958191871643066e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="13" Cut="1.8857143402099609e+01" cType="1" res="-5.2316212654113770e-01" rms="7.9439115524291992e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="-1.9414637088775635e+00" cType="1" res="-6.6106975078582764e-02" rms="7.7779116630554199e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.7542212605476379e-01" rms="6.8493919372558594e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.5308039300143719e-03" rms="7.8323388099670410e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="5" Cut="3.7982143402099609e+01" cType="1" res="-1.4292639493942261e+00" rms="8.1880702972412109e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.9046612083911896e-01" rms="8.1400785446166992e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.9037322998046875e-01" rms="8.1305980682373047e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="137">
+      <Node pos="s" depth="0" NCoef="0" IVar="6" Cut="1.6323330402374268e+00" cType="1" res="7.8980222344398499e-02" rms="7.7415552139282227e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="9" Cut="4.5847065746784210e-02" cType="1" res="1.2670621275901794e-01" rms="7.6947484016418457e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="5" Cut="9.0164085388183594e+01" cType="1" res="3.3895671367645264e-02" rms="7.6860461235046387e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.2414487153291702e-03" rms="7.6749839782714844e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.8669135570526123e-01" rms="9.2817611694335938e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="7.1626424789428711e-01" cType="1" res="7.2400677204132080e-01" rms="7.7238817214965820e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.4950190484523773e-02" rms="7.7774734497070312e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.3262008428573608e-01" rms="6.8178071975708008e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="2" Cut="2.4819641113281250e+01" cType="1" res="-8.3345651626586914e-01" rms="8.5363302230834961e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="16" Cut="2.9954710006713867e+00" cType="1" res="-4.6627467870712280e-01" rms="8.5252494812011719e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.4208778738975525e-01" rms="8.4652442932128906e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.1585116386413574e-01" rms="8.5846710205078125e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="8" Cut="1.2363126128911972e-01" cType="1" res="-3.2215187549591064e+00" rms="8.2169857025146484e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.6579933464527130e-01" rms="8.7868347167968750e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.5794988870620728e-01" rms="6.6306295394897461e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="138">
+      <Node pos="s" depth="0" NCoef="0" IVar="2" Cut="2.0577497482299805e+01" cType="1" res="1.2222352623939514e-01" rms="7.7250761985778809e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="3" Cut="-2.1713151931762695e+00" cType="1" res="3.3728361129760742e-01" rms="7.6345787048339844e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="1.1340296173095703e+02" cType="1" res="-9.6458417177200317e-01" rms="7.5392112731933594e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.1858514547348022e-02" rms="7.3076939582824707e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.8815134763717651e-01" rms="7.4726772308349609e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="1.8470856547355652e-01" cType="1" res="3.7518045306205750e-01" rms="7.6340122222900391e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.5255300402641296e-03" rms="7.4501919746398926e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.6603331118822098e-02" rms="7.7063236236572266e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="9" Cut="1.9186899065971375e-01" cType="1" res="-2.4269624054431915e-01" rms="7.8628091812133789e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="16" Cut="2.5264985561370850e+00" cType="1" res="-3.5715755820274353e-01" rms="7.8152408599853516e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.5815051794052124e-02" rms="7.7807216644287109e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7514334619045258e-01" rms="8.1523170471191406e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="4.9946475028991699e-01" cType="1" res="1.1604237556457520e+00" rms="8.2967767715454102e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0037570446729660e-01" rms="8.3882064819335938e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.2895182967185974e-01" rms="7.7571387290954590e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="139">
+      <Node pos="s" depth="0" NCoef="0" IVar="3" Cut="-2.1713323593139648e+00" cType="1" res="2.2979794070124626e-02" rms="7.7496767044067383e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="10" Cut="4.1872930526733398e-01" cType="1" res="-1.1272755861282349e+00" rms="7.4867620468139648e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="1.9570188224315643e-01" cType="1" res="-2.9049737453460693e+00" rms="7.2519664764404297e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.3541172146797180e-01" rms="7.0699515342712402e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.0052017644047737e-02" rms="7.7432069778442383e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="3.6883693933486938e-01" cType="1" res="3.1528270244598389e-01" rms="7.3630414009094238e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.1993312835693359e-01" rms="7.0380640029907227e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.8825270533561707e-01" rms="7.4189291000366211e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="12" Cut="3.1979635357856750e-01" cType="1" res="6.2221296131610870e-02" rms="7.7554802894592285e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="4.8658123016357422e+01" cType="1" res="-1.1708202958106995e-01" rms="7.6728410720825195e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.7637739479541779e-02" rms="6.8346109390258789e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4284690842032433e-03" rms="8.0614967346191406e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="6.9097369909286499e-01" cType="1" res="3.5291808843612671e-01" rms="7.8789539337158203e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3889800757169724e-02" rms="7.8542618751525879e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.6405937671661377e+00" rms="3.5990405082702637e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="140">
+      <Node pos="s" depth="0" NCoef="0" IVar="5" Cut="1.0607793807983398e+01" cType="1" res="8.8161006569862366e-02" rms="7.7312903404235840e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="16" Cut="2.5264985561370850e+00" cType="1" res="-1.7042718827724457e-01" rms="7.1556582450866699e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="1.1790458112955093e-01" cType="1" res="-2.3676852881908417e-01" rms="7.1331248283386230e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.9197118282318115e-02" rms="6.8936076164245605e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.8159023970365524e-02" rms="7.6227483749389648e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="3" Cut="-1.2564964294433594e+00" cType="1" res="1.6754509210586548e+00" rms="7.5254440307617188e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.9134227037429810e-01" rms="7.0699753761291504e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.5467930138111115e-02" rms="7.3868203163146973e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="15" Cut="1.2142689228057861e+00" cType="1" res="2.7157691121101379e-01" rms="8.1098728179931641e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="5" Cut="8.6567710876464844e+01" cType="1" res="5.5350077152252197e-01" rms="8.2428550720214844e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.4211649596691132e-02" rms="8.2256679534912109e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.2542724609375000e+00" rms="9.0673389434814453e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="8.7473176419734955e-02" cType="1" res="-1.2392655014991760e-01" rms="7.9026198387145996e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.2540861070156097e-03" rms="7.8393535614013672e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.5746159851551056e-01" rms="8.0687446594238281e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="141">
+      <Node pos="s" depth="0" NCoef="0" IVar="12" Cut="4.6282085776329041e-01" cType="1" res="9.4508603215217590e-02" rms="7.6575107574462891e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="10" Cut="7.1289551258087158e-01" cType="1" res="3.8745512720197439e-03" rms="7.6230845451354980e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="7" Cut="5.5028076171875000e+00" cType="1" res="-1.5324221551418304e-01" rms="7.7956056594848633e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.8253231942653656e-02" rms="7.5860037803649902e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.3786566257476807e-02" rms="8.1799955368041992e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="2.5653558969497681e-01" cType="1" res="3.7554794549942017e-01" rms="7.1848664283752441e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.8558885939419270e-03" rms="7.1948556900024414e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.8129898905754089e-01" rms="6.5088477134704590e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="10" Cut="5.4305624961853027e-01" cType="1" res="6.1317420005798340e-01" rms="7.8314652442932129e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="9.6842311322689056e-02" cType="1" res="4.4448128342628479e-01" rms="7.8068051338195801e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.1215328238904476e-02" rms="7.7428240776062012e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.2655713558197021e-01" rms="7.8852400779724121e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4734587669372559e+00" rms="3.9816520214080811e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="142">
+      <Node pos="s" depth="0" NCoef="0" IVar="10" Cut="6.6906809806823730e-01" cType="1" res="1.2786136567592621e-01" rms="7.6950888633728027e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="5" Cut="9.5775671005249023e+00" cType="1" res="-7.2188206017017365e-02" rms="7.8735094070434570e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="-5.7181298732757568e-01" cType="1" res="-5.0189483165740967e-01" rms="7.3621721267700195e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.9985332619398832e-03" rms="7.3126811981201172e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.1855527758598328e-01" rms="7.3715929985046387e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="4.8968037962913513e-01" cType="1" res="2.3234979808330536e-01" rms="8.2030372619628906e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.7296491209417582e-03" rms="8.1758975982666016e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7849083244800568e-01" rms="8.3573074340820312e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="12" Cut="3.3141234517097473e-01" cType="1" res="5.1095789670944214e-01" rms="7.3260874748229980e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="12" Cut="2.9976513981819153e-01" cType="1" res="3.6659309267997742e-01" rms="7.3006801605224609e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2964304536581039e-02" rms="7.2972855567932129e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.0510884523391724e-01" rms="7.0307049751281738e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="3.4899780154228210e-01" cType="1" res="7.2670302391052246e+00" rms="4.9440159797668457e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.6993128061294556e-01" rms="5.5682268142700195e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.9477288722991943e+00" rms="2.9040756225585938e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="143">
+      <Node pos="s" depth="0" NCoef="0" IVar="1" Cut="5.5338249206542969e+01" cType="1" res="1.8806454539299011e-01" rms="7.7172813415527344e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="4" Cut="5.5241294860839844e+01" cType="1" res="-1.4020483195781708e-01" rms="7.0117020606994629e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="3.2597702026367188e+01" cType="1" res="-6.0934044420719147e-02" rms="7.0010490417480469e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.3839553296566010e-01" rms="6.3503465652465820e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2002712115645409e-02" rms="7.1096410751342773e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="2" Cut="1.9809537887573242e+01" cType="1" res="-4.7431607246398926e+00" rms="6.0232634544372559e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.2050233483314514e-01" rms="5.8579769134521484e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.4498366117477417e-01" rms="5.6887350082397461e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="3" Cut="-2.1714916229248047e+00" cType="1" res="4.5197609066963196e-01" rms="8.2313518524169922e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="6.9552457332611084e-01" cType="1" res="-1.7646039724349976e+00" rms="7.9007773399353027e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.2999318838119507e-01" rms="7.9560570716857910e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3150234520435333e-01" rms="6.9338216781616211e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="6.8527793884277344e-01" cType="1" res="5.2184319496154785e-01" rms="8.2318582534790039e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.2408678233623505e-02" rms="8.2266139984130859e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.9983843564987183e-01" rms="8.2149257659912109e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="144">
+      <Node pos="s" depth="0" NCoef="0" IVar="2" Cut="2.5329633712768555e+01" cType="1" res="6.5741173923015594e-02" rms="7.7487792968750000e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="12" Cut="2.7769252657890320e-01" cType="1" res="1.4145998656749725e-01" rms="7.7275409698486328e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="7.6871055364608765e-01" cType="1" res="-7.5802080333232880e-02" rms="7.6510558128356934e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.8275323361158371e-02" rms="7.8613066673278809e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.3182509243488312e-02" rms="7.1416964530944824e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="7.1457749605178833e-01" cType="1" res="3.7317058444023132e-01" rms="7.8016223907470703e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.4051535874605179e-02" rms="7.8069500923156738e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.5594750642776489e-01" rms="5.8813776969909668e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="10" Cut="7.8236645460128784e-01" cType="1" res="-4.8994991183280945e-01" rms="7.8806705474853516e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="2.5207790732383728e-01" cType="1" res="-6.8417727947235107e-01" rms="7.9312252998352051e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.2965072691440582e-01" rms="7.8699679374694824e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.6043773293495178e-01" rms="8.4085149765014648e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="16" Cut="1.5029537677764893e+00" cType="1" res="8.8332885503768921e-01" rms="7.3688831329345703e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.1840525120496750e-03" rms="7.2463879585266113e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.0546787977218628e-01" rms="6.8816900253295898e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="145">
+      <Node pos="s" depth="0" NCoef="0" IVar="11" Cut="3.8674078881740570e-02" cType="1" res="5.1811661571264267e-02" rms="7.6945042610168457e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="15" Cut="3.7687542438507080e+00" cType="1" res="-1.9757904112339020e-01" rms="7.5039930343627930e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="5" Cut="8.3096351623535156e+01" cType="1" res="-1.5810105204582214e-01" rms="7.5033731460571289e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.4674454480409622e-02" rms="7.4871420860290527e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.4625816345214844e-01" rms="9.0727834701538086e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="2" Cut="2.0210329055786133e+01" cType="1" res="-2.4139530658721924e+00" rms="7.1994757652282715e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.4749729037284851e-01" rms="7.5732922554016113e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.1776105165481567e-01" rms="5.9182233810424805e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="3" Cut="1.9427890777587891e+00" cType="1" res="2.8486430644989014e-01" rms="7.8612179756164551e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="12" Cut="3.5369047522544861e-01" cType="1" res="3.8915029168128967e-01" rms="7.8727235794067383e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1465343646705151e-02" rms="7.8423280715942383e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2796305119991302e-01" rms="7.9210700988769531e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="0" Cut="5.1610122680664062e+01" cType="1" res="-1.1659600734710693e+00" rms="7.5514311790466309e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2340475618839264e-01" rms="7.1257128715515137e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.6892277002334595e-01" rms="7.5066118240356445e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="146">
+      <Node pos="s" depth="0" NCoef="0" IVar="10" Cut="9.6936964988708496e-01" cType="1" res="2.2517767548561096e-01" rms="7.6871738433837891e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="12" Cut="5.5071067810058594e-01" cType="1" res="2.0819833874702454e-01" rms="7.6826472282409668e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="1.9426882266998291e+00" cType="1" res="1.4581011235713959e-01" rms="7.6662840843200684e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1530541814863682e-02" rms="7.6701006889343262e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.1876223981380463e-01" rms="7.5329074859619141e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="4.6126151084899902e-01" cType="1" res="1.0241428613662720e+00" rms="7.8480038642883301e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.9294321835041046e-02" rms="7.7942547798156738e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.4828085899353027e+00" rms="2.1262481212615967e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="5" Cut="1.8764881134033203e+01" cType="1" res="3.8596696853637695e+00" rms="7.7919464111328125e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.7665546536445618e-01" rms="7.3183660507202148e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.6074869632720947e+00" rms="7.5353131294250488e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="147">
+      <Node pos="s" depth="0" NCoef="0" IVar="2" Cut="1.2798708915710449e+01" cType="1" res="1.2921832501888275e-01" rms="7.6800036430358887e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="10" Cut="7.3112535476684570e-01" cType="1" res="9.9497509002685547e-01" rms="7.6230187416076660e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="1.0820420086383820e-01" cType="1" res="6.9035261869430542e-01" rms="7.8598275184631348e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.5307173132896423e-02" rms="7.7998867034912109e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.2446981072425842e-01" rms="7.9010353088378906e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="13" Cut="1.5000000000000000e+01" cType="1" res="1.9733308553695679e+00" rms="6.7141356468200684e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2541393935680389e-01" rms="6.5554413795471191e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.3552359342575073e-01" rms="6.7010197639465332e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="3" Cut="1.0285199880599976e+00" cType="1" res="5.8536663651466370e-02" rms="7.6803293228149414e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="4.9783223867416382e-01" cType="1" res="-6.6549926996231079e-02" rms="7.6609997749328613e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.1063079833984375e-02" rms="7.6522946357727051e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.7852256298065186e-01" rms="7.9161944389343262e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="4.1303300857543945e-01" cType="1" res="4.5333418250083923e-01" rms="7.7277526855468750e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3780680485069752e-02" rms="7.6879801750183105e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.9184264540672302e-01" rms="7.7801318168640137e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="148">
+      <Node pos="s" depth="0" NCoef="0" IVar="3" Cut="1.0285199880599976e+00" cType="1" res="9.8817571997642517e-02" rms="7.7067637443542480e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="13" Cut="1.8857143402099609e+01" cType="1" res="-1.6178755089640617e-02" rms="7.6765193939208984e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="5.2561492919921875e+01" cType="1" res="1.2414803355932236e-01" rms="7.5919537544250488e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.5827975720167160e-02" rms="6.8884391784667969e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.9133556187152863e-02" rms="8.1422252655029297e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="3" Cut="-5.8995646238327026e-01" cType="1" res="-6.0048949718475342e-01" rms="7.9926185607910156e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.5645921230316162e-02" rms="8.1751785278320312e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.6721318662166595e-01" rms="7.8544702529907227e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="3" Cut="2.2693233489990234e+00" cType="1" res="4.6197777986526489e-01" rms="7.7903690338134766e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="12" Cut="2.7769252657890320e-01" cType="1" res="6.4067065715789795e-01" rms="7.7782273292541504e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.6179890893399715e-03" rms="7.5542225837707520e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.5440107882022858e-01" rms="7.9734539985656738e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="5.5994969606399536e-01" cType="1" res="-1.9863896369934082e+00" rms="7.5397496223449707e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.7953162193298340e-01" rms="7.1889042854309082e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.2455623745918274e-01" rms="8.0392780303955078e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="149">
+      <Node pos="s" depth="0" NCoef="0" IVar="3" Cut="-2.1713171005249023e+00" cType="1" res="5.7627428323030472e-02" rms="7.6722164154052734e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="12" Cut="6.0096281766891479e-01" cType="1" res="-1.3045622110366821e+00" rms="7.3109745979309082e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="4.7734710574150085e-01" cType="1" res="-1.6629854440689087e+00" rms="7.2448010444641113e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.0007394552230835e-01" rms="7.2902231216430664e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.4949891269207001e-02" rms="6.9176316261291504e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.8018653392791748e-01" rms="6.9699487686157227e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="11" Cut="1.1434712260961533e-01" cType="1" res="1.0226991772651672e-01" rms="7.6796798706054688e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="9.1114884614944458e-01" cType="1" res="-1.0333432815968990e-02" rms="7.5742139816284180e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.1862698718905449e-02" rms="7.5782470703125000e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4015658199787140e-01" rms="7.3299741744995117e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="5.2622252702713013e-01" cType="1" res="4.6263945102691650e-01" rms="7.9972271919250488e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.7004159986972809e-02" rms="7.9939665794372559e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.4814296960830688e-01" rms="7.4190058708190918e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="150">
+      <Node pos="s" depth="0" NCoef="0" IVar="2" Cut="3.3613094329833984e+01" cType="1" res="1.7063249647617340e-01" rms="7.6803612709045410e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="10" Cut="2.4491064250469208e-01" cType="1" res="1.9070328772068024e-01" rms="7.6761641502380371e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="1.7103964090347290e+00" cType="1" res="-5.9017759561538696e-01" rms="7.9905953407287598e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.2058072537183762e-02" rms="8.0745525360107422e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.0510413646697998e-01" rms="7.4168715476989746e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="6.8838834762573242e-01" cType="1" res="2.4067966639995575e-01" rms="7.6528887748718262e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2723225168883801e-02" rms="7.6487360000610352e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.0379368066787720e-01" rms="7.3878626823425293e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="3" Cut="1.1612941324710846e-01" cType="1" res="-1.9910136461257935e+00" rms="7.8238830566406250e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.1793430447578430e-02" rms="8.1086387634277344e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="5.4754984378814697e-01" cType="1" res="-3.2419056892395020e+00" rms="7.3546485900878906e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.5099090337753296e-01" rms="6.6673636436462402e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.1246045231819153e-01" rms="7.6181483268737793e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="151">
+      <Node pos="s" depth="0" NCoef="0" IVar="12" Cut="4.4644087553024292e-02" cType="1" res="1.6390937566757202e-01" rms="7.6709756851196289e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="10" Cut="6.3108682632446289e-01" cType="1" res="-1.7149355411529541e+00" rms="7.4107723236083984e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="1.2648849189281464e-01" cType="1" res="4.7686415910720825e-01" rms="7.9671430587768555e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.0493980050086975e-01" rms="7.9276099205017090e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.2544059157371521e-01" rms="7.4864640235900879e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="6" Cut="-9.4194076538085938e+01" cType="1" res="-2.8647322654724121e+00" rms="6.8256206512451172e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.2768615484237671e-01" rms="6.5045604705810547e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.6167990863323212e-01" rms="7.5685343742370605e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="3" Cut="-1.2571527957916260e+00" cType="1" res="1.9930721819400787e-01" rms="7.6713781356811523e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="-2.0191073417663574e+00" cType="1" res="5.6265741586685181e-01" rms="7.7176704406738281e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.7894378900527954e-02" rms="7.6962237358093262e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1249002814292908e-01" rms="7.6989083290100098e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="3" Cut="8.3262735605239868e-01" cType="1" res="1.1632484942674637e-01" rms="7.6583490371704102e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.9113875925540924e-02" rms="7.6027956008911133e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.5350026339292526e-02" rms="7.7500295639038086e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="152">
+      <Node pos="s" depth="0" NCoef="0" IVar="9" Cut="5.9601181745529175e-01" cType="1" res="2.3535225540399551e-02" rms="7.6716904640197754e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="4" Cut="9.8685317993164062e+01" cType="1" res="1.3081857003271580e-02" rms="7.6696825027465820e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="8.8941726684570312e+01" cType="1" res="9.4150386750698090e-02" rms="7.3989934921264648e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.9729077816009521e-02" rms="7.3412942886352539e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.1366783380508423e-01" rms="8.0326976776123047e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="1.1980758666992188e+02" cType="1" res="-3.6337643861770630e-01" rms="8.8086967468261719e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.9809657335281372e-01" rms="8.4589700698852539e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.6249232254922390e-03" rms="9.0329532623291016e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.5924737453460693e-01" rms="7.6241726875305176e+00" purity="1.0000000000000000e+00" nType="-99"/>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="153">
+      <Node pos="s" depth="0" NCoef="0" IVar="12" Cut="6.9423133134841919e-01" cType="1" res="1.5845204889774323e-01" rms="7.6808533668518066e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="10" Cut="6.2005388736724854e-01" cType="1" res="1.2646706402301788e-01" rms="7.6676974296569824e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="1.7141274213790894e+00" cType="1" res="-8.3896659314632416e-02" rms="7.8832287788391113e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.2126053683459759e-02" rms="7.9023013114929199e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.4085067808628082e-01" rms="7.6735625267028809e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="3.7450435757637024e-01" cType="1" res="3.9717602729797363e-01" rms="7.3722562789916992e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.3061841726303101e-02" rms="7.3530602455139160e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1001430749893188e+00" rms="4.8744540214538574e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="11" Cut="4.0298998355865479e-02" cType="1" res="2.0983803272247314e+00" rms="8.2108011245727539e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="1.2440863847732544e+00" cType="1" res="8.0730807781219482e-01" rms="8.0184850692749023e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.3745768368244171e-01" rms="7.9449152946472168e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.7421728372573853e-01" rms="6.9080386161804199e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="2.1591617166996002e-01" cType="1" res="4.4447641372680664e+00" rms="8.0345973968505859e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.6528167724609375e-01" rms="8.2942485809326172e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.9450098276138306e+00" rms="6.4574699401855469e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="154">
+      <Node pos="s" depth="0" NCoef="0" IVar="10" Cut="8.8792002201080322e-01" cType="1" res="1.0669807344675064e-01" rms="7.6715898513793945e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="7" Cut="-7.9208786010742188e+01" cType="1" res="6.6526062786579132e-02" rms="7.6831169128417969e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="12" Cut="1.3884626328945160e-01" cType="1" res="-8.4822013974189758e-02" rms="7.4464650154113770e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.4191587269306183e-01" rms="7.1755819320678711e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.3270685970783234e-03" rms="7.4694714546203613e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="5" Cut="1.9387556076049805e+01" cType="1" res="4.6355211734771729e-01" rms="8.2586326599121094e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.0252789147198200e-03" rms="8.0314102172851562e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.8195289373397827e-01" rms="8.6354904174804688e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="12" Cut="1.0688982903957367e-01" cType="1" res="1.2213560342788696e+00" rms="7.2563624382019043e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="1.5843465924263000e-02" cType="1" res="3.8886055350303650e-01" rms="7.2773156166076660e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.0664238780736923e-01" rms="7.0996279716491699e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.3110699057579041e-01" rms="7.1915936470031738e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="1.2353497743606567e-01" cType="1" res="5.1381788253784180e+00" rms="5.7113742828369141e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.4134876132011414e-01" rms="5.8844542503356934e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3625614643096924e+00" rms="4.5040049552917480e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="155">
+      <Node pos="s" depth="0" NCoef="0" IVar="11" Cut="5.5022138357162476e-01" cType="1" res="1.6157302260398865e-01" rms="7.6774091720581055e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="7" Cut="-8.2581062316894531e+01" cType="1" res="1.4964610338211060e-01" rms="7.6753602027893066e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="6.2296718358993530e-01" cType="1" res="3.1917124986648560e-02" rms="7.4523172378540039e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.1223836839199066e-02" rms="7.7155871391296387e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.0881550386548042e-02" rms="7.1798009872436523e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="16" Cut="1.1372731924057007e+00" cType="1" res="4.5653271675109863e-01" rms="8.2204771041870117e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.7070973068475723e-02" rms="8.1535787582397461e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.6120028495788574e-01" rms="8.4537267684936523e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.4418760538101196e-01" rms="7.5216822624206543e+00" purity="1.0000000000000000e+00" nType="-99"/>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="156">
+      <Node pos="s" depth="0" NCoef="0" IVar="13" Cut="1.8857143402099609e+01" cType="1" res="1.1284191906452179e-01" rms="7.6984686851501465e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="5" Cut="8.2504554748535156e+01" cType="1" res="2.3528794944286346e-01" rms="7.6138820648193359e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="5" Cut="4.4291296005249023e+00" cType="1" res="2.5087404251098633e-01" rms="7.6037793159484863e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.6436072587966919e-02" rms="7.1862692832946777e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.4400748312473297e-02" rms="7.6313924789428711e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.4591525793075562e-01" rms="8.9814472198486328e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="10" Cut="7.4946671724319458e-01" cType="1" res="-4.4510805606842041e-01" rms="8.0491428375244141e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="-1.9261353015899658e+00" cType="1" res="-7.7054083347320557e-01" rms="8.1644191741943359e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.5624872446060181e-01" rms="7.9444637298583984e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.1725799739360809e-01" rms="8.1562404632568359e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="9.9429823458194733e-02" cType="1" res="4.5247313380241394e-01" rms="7.6508793830871582e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.5989350676536560e-01" rms="7.3833522796630859e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4032767713069916e-01" rms="7.5980319976806641e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="157">
+      <Node pos="s" depth="0" NCoef="0" IVar="14" Cut="4.7619048506021500e-02" cType="1" res="2.1023565903306007e-02" rms="7.6878829002380371e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="5" Cut="2.4794223785400391e+01" cType="1" res="1.2208247184753418e+00" rms="8.0316505432128906e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="2.1716289520263672e+00" cType="1" res="1.5787678956985474e+00" rms="7.9353237152099609e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.7938324213027954e-01" rms="7.8614606857299805e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.6753526926040649e-01" rms="8.0583772659301758e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="3.5426509380340576e-01" cType="1" res="-1.5353374481201172e+00" rms="8.2320919036865234e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4629842340946198e-01" rms="8.6284351348876953e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.5538830757141113e-01" rms="7.6835446357727051e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="10" Cut="4.9044317007064819e-01" cType="1" res="-3.8894489407539368e-02" rms="7.6653890609741211e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="7.6231420040130615e-02" cType="1" res="-4.4450944662094116e-01" rms="7.9855780601501465e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.5375457704067230e-01" rms="7.8555650711059570e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.9019415900111198e-03" rms="8.0835628509521484e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="5.0055897235870361e-01" cType="1" res="1.5668162703514099e-01" rms="7.4982876777648926e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.5744048655033112e-03" rms="7.4861936569213867e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1901856660842896e+00" rms="5.5101385116577148e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="158">
+      <Node pos="s" depth="0" NCoef="0" IVar="10" Cut="4.8942524194717407e-01" cType="1" res="9.4590410590171814e-02" rms="7.6795392036437988e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="7" Cut="-7.9880393981933594e+01" cType="1" res="-2.5493153929710388e-01" rms="7.9943790435791016e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="2.7838754653930664e-01" cType="1" res="-6.8841975927352905e-01" rms="7.7300066947937012e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.2800313532352448e-01" rms="7.7287201881408691e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.9663676023483276e-01" rms="7.1241831779479980e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="6" Cut="1.6080056428909302e+00" cType="1" res="3.2913041114807129e-01" rms="8.3016176223754883e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1345265060663223e-01" rms="8.2844095230102539e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.9984123110771179e-01" rms="8.1736774444580078e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="12" Cut="4.8943224549293518e-01" cType="1" res="2.6747971773147583e-01" rms="7.5129251480102539e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="12" Cut="4.1938987374305725e-01" cType="1" res="2.0069627463817596e-01" rms="7.5015349388122559e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.7109510311856866e-04" rms="7.4988427162170410e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.9164027273654938e-01" rms="7.4322791099548340e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="5.1156610250473022e-01" cType="1" res="4.8614230155944824e+00" rms="6.8408389091491699e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.9020329713821411e-01" rms="7.1740379333496094e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.5613095760345459e+00" rms="4.1773905754089355e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="159">
+      <Node pos="s" depth="0" NCoef="0" IVar="10" Cut="7.3184090852737427e-01" cType="1" res="8.2882590591907501e-02" rms="7.7127737998962402e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="12" Cut="5.0481814146041870e-01" cType="1" res="-5.5291466414928436e-02" rms="7.8416242599487305e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="1.1763826751708984e+02" cType="1" res="-1.6056585311889648e-01" rms="7.8284726142883301e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.7704935073852539e-02" rms="7.6511592864990234e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2527693808078766e-01" rms="9.1303281784057617e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="7" Cut="1.9747280120849609e+01" cType="1" res="6.1367982625961304e-01" rms="7.8919401168823242e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1281368136405945e-01" rms="7.8362445831298828e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.5862993597984314e-01" rms="7.8745074272155762e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="12" Cut="2.5653558969497681e-01" cType="1" res="5.7825767993927002e-01" rms="7.2102494239807129e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="1.8025813624262810e-02" cType="1" res="3.2924550771713257e-01" rms="7.1880726814270020e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.8642745018005371e-02" rms="6.9914379119873047e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1579316109418869e-01" rms="7.3222298622131348e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="5.4667796939611435e-03" cType="1" res="4.4177441596984863e+00" rms="6.4197573661804199e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.1074898838996887e-01" rms="6.4534630775451660e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.6476724147796631e+00" rms="3.2107186317443848e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="160">
+      <Node pos="s" depth="0" NCoef="0" IVar="11" Cut="4.1477075219154358e-01" cType="1" res="2.2384785115718842e-01" rms="7.7042665481567383e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="12" Cut="6.9423133134841919e-01" cType="1" res="1.9315470755100250e-01" rms="7.6932778358459473e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="7.7139359712600708e-01" cType="1" res="1.6511814296245575e-01" rms="7.6866393089294434e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.7836025953292847e-03" rms="7.7803010940551758e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.2539204955101013e-02" rms="7.1604285240173340e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="13" Cut="6.0476188659667969e+00" cType="1" res="1.9378912448883057e+00" rms="7.9023633003234863e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.5242262184619904e-01" rms="8.0133733749389648e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.2905774712562561e-01" rms="7.6276903152465820e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="3" Cut="-1.0955331474542618e-01" cType="1" res="1.8257377147674561e+00" rms="8.0975866317749023e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="12" Cut="2.3329070210456848e-01" cType="1" res="2.9137399196624756e+00" rms="7.9154539108276367e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.0855923891067505e-01" rms="8.3317823410034180e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.8433266878128052e-01" rms="6.7260355949401855e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="2" Cut="2.2379352569580078e+01" cType="1" res="6.4155864715576172e-01" rms="8.1273956298828125e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.1456576883792877e-01" rms="8.0452947616577148e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.8829438090324402e-01" rms="8.0365962982177734e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="161">
+      <Node pos="s" depth="0" NCoef="0" IVar="12" Cut="4.6177141368389130e-02" cType="1" res="4.6503961086273193e-02" rms="7.6554050445556641e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="1" Cut="7.6459495544433594e+01" cType="1" res="-1.3524183034896851e+00" rms="7.5148129463195801e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="7" Cut="-9.2427612304687500e+01" cType="1" res="-3.3702838420867920e-01" rms="7.2229480743408203e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.7689447999000549e-01" rms="6.3909916877746582e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.1303018331527710e-01" rms="7.4255785942077637e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="3.7347730249166489e-02" cType="1" res="-3.3678135871887207e+00" rms="7.6747560501098633e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.2778830528259277e-01" rms="6.8457584381103516e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.4360315501689911e-01" rms="8.4121065139770508e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="10" Cut="9.4441282749176025e-01" cType="1" res="7.4533633887767792e-02" rms="7.6555838584899902e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="5.8952289819717407e-01" cType="1" res="5.8272086083889008e-02" rms="7.6499409675598145e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.5335418805480003e-03" rms="7.6471104621887207e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.1607927083969116e-01" rms="7.8077235221862793e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="17" Cut="2.3333332538604736e+00" cType="1" res="3.6112387180328369e+00" rms="8.0513811111450195e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.3720705509185791e+00" rms="6.2774157524108887e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.5541538149118423e-02" rms="8.0885629653930664e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="162">
+      <Node pos="s" depth="0" NCoef="0" IVar="2" Cut="3.1604795455932617e+01" cType="1" res="8.4050260484218597e-02" rms="7.6756033897399902e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="9" Cut="4.1990619152784348e-02" cType="1" res="1.1179774999618530e-01" rms="7.6722645759582520e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="5" Cut="4.7561176300048828e+01" cType="1" res="1.9459666684269905e-02" rms="7.6350021362304688e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.0498847588896751e-02" rms="7.5787196159362793e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.8319773077964783e-01" rms="9.1407985687255859e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="7.1626424789428711e-01" cType="1" res="6.2517774105072021e-01" rms="7.8564543724060059e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.6454824507236481e-02" rms="7.8691554069519043e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.2475360631942749e-01" rms="7.3606510162353516e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="16" Cut="1.4432084560394287e+00" cType="1" res="-1.5673453807830811e+00" rms="7.6936230659484863e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="7.8138315677642822e-01" cType="1" res="-2.1345970630645752e+00" rms="7.6397390365600586e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.2868429422378540e-01" rms="7.8070349693298340e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.0950759351253510e-02" rms="5.8341856002807617e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.8078771233558655e-01" rms="7.2059640884399414e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="163">
+      <Node pos="s" depth="0" NCoef="0" IVar="13" Cut="3.2857143402099609e+01" cType="1" res="1.0796621441841125e-01" rms="7.6886038780212402e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="4" Cut="3.4421112060546875e+02" cType="1" res="9.8900489509105682e-02" rms="7.6832151412963867e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="2.8639105224609375e+02" cType="1" res="1.1056064069271088e-01" rms="7.6756057739257812e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.6984052490442991e-03" rms="7.6678586006164551e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0752016305923462e+00" rms="9.1347570419311523e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.8275127410888672e+00" rms="9.1681003570556641e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.9940369129180908e+00" rms="8.9381637573242188e+00" purity="1.0000000000000000e+00" nType="-99"/>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="164">
+      <Node pos="s" depth="0" NCoef="0" IVar="9" Cut="4.8277002573013306e-01" cType="1" res="1.0336203128099442e-01" rms="7.6551017761230469e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="10" Cut="1.8656118214130402e-01" cType="1" res="8.4527514874935150e-02" rms="7.6485514640808105e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="4.1330360412597656e+01" cType="1" res="-1.1484196186065674e+00" rms="8.0684385299682617e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.8897773623466492e-01" rms="7.6659021377563477e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.6389198899269104e-02" rms="8.1355581283569336e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="2.0379009842872620e-01" cType="1" res="1.2160959094762802e-01" rms="7.6324810981750488e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.6339915394783020e-03" rms="7.5986738204956055e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.0328814685344696e-02" rms="7.9021177291870117e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="11" Cut="8.5132494568824768e-02" cType="1" res="1.8255108594894409e+00" rms="8.0478773117065430e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="5.2464991807937622e-01" cType="1" res="6.1383008956909180e-01" rms="8.1324090957641602e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.2469638288021088e-01" rms="7.7389135360717773e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.2673210501670837e-01" rms="8.1673278808593750e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.4977302551269531e-01" rms="6.9931392669677734e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="165">
+      <Node pos="s" depth="0" NCoef="0" IVar="9" Cut="4.5847065746784210e-02" cType="1" res="1.4679703116416931e-01" rms="7.6485538482666016e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="9" Cut="2.1803816780447960e-03" cType="1" res="5.9509828686714172e-02" rms="7.5979418754577637e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="1.9337040185928345e-01" cType="1" res="2.4584280326962471e-02" rms="7.5838956832885742e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.3166289553046227e-02" rms="7.5318450927734375e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.0989597141742706e-02" rms="7.9340510368347168e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="4.3978932499885559e-01" cType="1" res="1.5460566282272339e+00" rms="8.0338907241821289e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.4236323833465576e-02" rms="8.7568655014038086e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.2467433810234070e-01" rms="7.6863551139831543e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="10" Cut="6.0082930326461792e-01" cType="1" res="6.2411624193191528e-01" rms="7.9025688171386719e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="16" Cut="3.9325881004333496e-01" cType="1" res="2.6719847321510315e-01" rms="7.9761610031127930e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.5023591518402100e-02" rms="8.0092868804931641e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.3321603238582611e-02" rms="7.8846631050109863e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="1.4937959611415863e-01" cType="1" res="1.9497327804565430e+00" rms="7.4753022193908691e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.5840251743793488e-01" rms="7.3526368141174316e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.8146649599075317e-01" rms="7.4757466316223145e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="166">
+      <Node pos="s" depth="0" NCoef="0" IVar="11" Cut="1.5317913889884949e-01" cType="1" res="2.1323174238204956e-01" rms="7.6531867980957031e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="14" Cut="4.7619048506021500e-02" cType="1" res="1.0688723623752594e-01" rms="7.5867309570312500e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="13" Cut="1.2000000000000000e+01" cType="1" res="1.2076698541641235e+00" rms="7.8588728904724121e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.8281274437904358e-01" rms="7.5639896392822266e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.1871479526162148e-03" rms="8.1825580596923828e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="2.5387486815452576e-01" cType="1" res="5.8923006057739258e-02" rms="7.5710124969482422e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.9833216071128845e-01" rms="8.1992206573486328e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.7988988272845745e-04" rms="7.5444064140319824e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="3" Cut="1.9423816204071045e+00" cType="1" res="7.0922225713729858e-01" rms="7.9370121955871582e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="-1.9864770174026489e+00" cType="1" res="9.6309649944305420e-01" rms="7.9229655265808105e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.6655035316944122e-01" rms="7.6830387115478516e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.6203425824642181e-01" rms="7.9176421165466309e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="0" Cut="5.7180530548095703e+01" cType="1" res="-1.6791597604751587e+00" rms="7.6668949127197266e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3652325607836246e-02" rms="7.4977574348449707e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.0179648399353027e-01" rms="7.3835525512695312e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="167">
+      <Node pos="s" depth="0" NCoef="0" IVar="9" Cut="2.5194370746612549e-01" cType="1" res="1.8277837336063385e-01" rms="7.6745228767395020e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="17" Cut="4.2857141494750977e+00" cType="1" res="1.2999719381332397e-01" rms="7.6421079635620117e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="2" Cut="1.0730984687805176e+01" cType="1" res="6.7634768784046173e-02" rms="7.6648945808410645e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7099502682685852e-01" rms="7.3079271316528320e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.2587643228471279e-02" rms="7.6703457832336426e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="7" Cut="2.0020601272583008e+01" cType="1" res="8.6592453718185425e-01" rms="7.3279118537902832e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2299699336290359e-01" rms="7.2747321128845215e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.1495782136917114e-01" rms="7.7037124633789062e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="4" Cut="3.9023975372314453e+01" cType="1" res="1.0200978517532349e+00" rms="8.1258392333984375e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="3.8297228515148163e-02" cType="1" res="2.3473696708679199e+00" rms="7.4278016090393066e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.5454566478729248e-01" rms="7.4472227096557617e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.8771961927413940e-01" rms="7.0802788734436035e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="4.8807216644287109e+01" cType="1" res="6.9210189580917358e-01" rms="8.2564725875854492e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.7916165292263031e-01" rms="7.3393797874450684e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.5635696053504944e-01" rms="8.3834600448608398e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="168">
+      <Node pos="s" depth="0" NCoef="0" IVar="12" Cut="4.0999373793601990e-01" cType="1" res="1.1376044899225235e-01" rms="7.6352310180664062e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="10" Cut="7.8951984643936157e-01" cType="1" res="-3.3457599580287933e-02" rms="7.5917625427246094e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="6" Cut="-9.3489624023437500e+01" cType="1" res="-1.6629651188850403e-01" rms="7.6915864944458008e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.1382368206977844e-02" rms="7.4013619422912598e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.0083069801330566e-02" rms="8.1993398666381836e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="2.1220110356807709e-01" cType="1" res="6.2354838848114014e-01" rms="7.0406169891357422e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.3164356127381325e-02" rms="6.9774432182312012e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0328809022903442e+00" rms="5.5119791030883789e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="10" Cut="5.4945558309555054e-01" cType="1" res="6.7395383119583130e-01" rms="7.7729725837707520e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="7.2849690914154053e-02" cType="1" res="3.8130855560302734e-01" rms="7.7741680145263672e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.3942967653274536e-02" rms="7.6654410362243652e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.9863371551036835e-01" rms="7.8963122367858887e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="4.5208975672721863e-01" cType="1" res="3.1280782222747803e+00" rms="7.3158941268920898e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.3781883716583252e-01" rms="7.4033565521240234e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2565633058547974e+00" rms="3.8020687103271484e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="169">
+      <Node pos="s" depth="0" NCoef="0" IVar="10" Cut="2.4850709736347198e-01" cType="1" res="2.2363893687725067e-01" rms="7.6373801231384277e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="3" Cut="1.1429866403341293e-01" cType="1" res="-6.2818509340286255e-01" rms="8.1340913772583008e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="-1.0854938030242920e+00" cType="1" res="1.4292284846305847e-01" rms="8.1128320693969727e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.2650139629840851e-01" rms="7.8278102874755859e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.6430019736289978e-01" rms="8.2160949707031250e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="0" Cut="1.3897779846191406e+02" cType="1" res="-1.3588374853134155e+00" rms="8.0866222381591797e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.7868655920028687e-01" rms="8.0050506591796875e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.0454183816909790e+00" rms="8.1682052612304688e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="12" Cut="3.6714044213294983e-01" cType="1" res="2.7897271513938904e-01" rms="7.6006908416748047e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="7" Cut="-8.2581062316894531e+01" cType="1" res="1.5126492083072662e-01" rms="7.5375361442565918e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.2100642323493958e-02" rms="7.3005151748657227e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.2748671770095825e-02" rms="8.0488929748535156e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="6.3889813423156738e-01" cType="1" res="6.2618374824523926e-01" rms="7.7591814994812012e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.4319901615381241e-02" rms="7.7307858467102051e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4654635190963745e+00" rms="3.9153828620910645e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="170">
+      <Node pos="s" depth="0" NCoef="0" IVar="5" Cut="8.2485351562500000e+01" cType="1" res="2.8023123741149902e-02" rms="7.6718273162841797e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="5" Cut="5.0774368286132812e+01" cType="1" res="3.9751417934894562e-02" rms="7.6632213592529297e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="3.3822962641716003e-01" cType="1" res="4.9402378499507904e-03" rms="7.6285462379455566e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.0530785471200943e-01" rms="8.0812864303588867e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.7232416905462742e-03" rms="7.5511131286621094e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="7" Cut="1.5717634201049805e+01" cType="1" res="1.9499906301498413e+00" rms="9.1709556579589844e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.5127178430557251e-01" rms="9.2074918746948242e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1322910785675049e+00" rms="8.6301631927490234e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="15" Cut="2.1009156107902527e-01" cType="1" res="-2.6998958587646484e+00" rms="9.0597496032714844e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.6129024028778076e-01" rms="9.6481466293334961e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.3355599641799927e-01" rms="8.1077966690063477e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="171">
+      <Node pos="s" depth="0" NCoef="0" IVar="9" Cut="4.9885934591293335e-01" cType="1" res="4.4911298900842667e-02" rms="7.6066346168518066e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="10" Cut="3.3515667915344238e-01" cType="1" res="2.9473911970853806e-02" rms="7.6011857986450195e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="5" Cut="3.0367187500000000e+01" cType="1" res="-4.4663089513778687e-01" rms="8.0492229461669922e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.8797760903835297e-02" rms="7.9647908210754395e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4150850474834442e-01" rms="8.6010007858276367e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="6.6351336240768433e-01" cType="1" res="9.6729330718517303e-02" rms="7.5333232879638672e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.9018431454896927e-03" rms="7.5290040969848633e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2365586757659912e+00" rms="5.6298608779907227e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="0" Cut="4.7010971069335938e+01" cType="1" res="1.6225484609603882e+00" rms="7.9884982109069824e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="2" Cut="1.8399745941162109e+01" cType="1" res="3.2891478538513184e+00" rms="7.0862884521484375e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.7164103388786316e-01" rms="7.6706495285034180e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.1467341184616089e-01" rms="6.3888731002807617e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="2.5088238716125488e-01" cType="1" res="3.7635242938995361e-01" rms="8.3878498077392578e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.7578526139259338e-01" rms="7.7831177711486816e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.8065540790557861e-01" rms="8.5314207077026367e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="172">
+      <Node pos="s" depth="0" NCoef="0" IVar="10" Cut="5.4944413900375366e-01" cType="1" res="5.0866398960351944e-02" rms="7.6289434432983398e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="3" Cut="-1.7143530845642090e+00" cType="1" res="-1.9100481271743774e-01" rms="7.8791580200195312e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="1.1278596496582031e+02" cType="1" res="-1.2522388696670532e+00" rms="7.4764480590820312e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.0317640006542206e-01" rms="7.3295006752014160e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.4590315818786621e-01" rms="7.5810279846191406e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="4.6282085776329041e-01" cType="1" res="-4.4503081589937210e-02" rms="7.9219865798950195e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.6320898234844208e-02" rms="7.9417519569396973e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.9057170748710632e-02" rms="7.8617029190063477e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="12" Cut="4.3692174553871155e-01" cType="1" res="2.3994593322277069e-01" rms="7.4219861030578613e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="2.2354996204376221e-01" cType="1" res="1.4388243854045868e-01" rms="7.4080986976623535e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.8594195395708084e-03" rms="7.3946833610534668e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.3643449544906616e-01" rms="7.4096269607543945e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="5.8233636617660522e-01" cType="1" res="5.5365371704101562e+00" rms="6.1545877456665039e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.1206660270690918e-01" rms="6.3254299163818359e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.9947251081466675e+00" rms="3.1536026000976562e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="173">
+      <Node pos="s" depth="0" NCoef="0" IVar="12" Cut="1.8512834608554840e-01" cType="1" res="8.2039117813110352e-02" rms="7.6443338394165039e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="5" Cut="8.8548011779785156e+01" cType="1" res="-2.2284218668937683e-01" rms="7.4991025924682617e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="14" Cut="4.7619048506021500e-02" cType="1" res="-1.8903961777687073e-01" rms="7.4725246429443359e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.3970519006252289e-01" rms="7.9255757331848145e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.9464900046586990e-02" rms="7.4511895179748535e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.5326195955276489e+00" rms="9.3076915740966797e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="10" Cut="8.1682831048965454e-01" cType="1" res="2.0269946753978729e-01" rms="7.6977195739746094e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="3.3533137291669846e-02" cType="1" res="1.4866082370281219e-01" rms="7.6948204040527344e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.4036792814731598e-02" rms="7.5261049270629883e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.9295466393232346e-02" rms="7.8304443359375000e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="5.1526927947998047e+01" cType="1" res="6.6201286315917969e+00" rms="4.7984147071838379e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.6722223758697510e-01" rms="4.8607759475708008e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.3590090274810791e+00" rms="3.1963205337524414e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="174">
+      <Node pos="s" depth="0" NCoef="0" IVar="12" Cut="9.2564173042774200e-02" cType="1" res="9.9289603531360626e-02" rms="7.6505804061889648e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="0" Cut="1.0796338653564453e+02" cType="1" res="-5.0745260715484619e-01" rms="7.6452021598815918e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="5" Cut="3.5077568054199219e+01" cType="1" res="-2.5317078828811646e-01" rms="7.4946050643920898e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.9961558580398560e-02" rms="7.3499755859375000e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.4789943099021912e-01" rms="8.2372407913208008e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="9.2787361145019531e-01" cType="1" res="-2.1002457141876221e+00" rms="8.3539724349975586e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.2775520086288452e-01" rms="7.9390087127685547e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.6104704141616821e-01" rms="8.6034393310546875e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="10" Cut="8.8526731729507446e-01" cType="1" res="1.4989446103572845e-01" rms="7.6488547325134277e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="16" Cut="3.4606206417083740e+00" cType="1" res="1.2532909214496613e-01" rms="7.6567654609680176e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.1250531319528818e-03" rms="7.6462607383728027e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.1199035644531250e-01" rms="7.9047203063964844e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="9.0196263790130615e-01" cType="1" res="2.3364472389221191e+00" rms="6.5492916107177734e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.2554410435259342e-03" rms="6.4116520881652832e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.0703516006469727e-01" rms="5.7911343574523926e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="175">
+      <Node pos="s" depth="0" NCoef="0" IVar="0" Cut="2.6158029174804688e+02" cType="1" res="7.8640878200531006e-02" rms="7.6334629058837891e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="1" Cut="1.2135253906250000e+02" cType="1" res="1.0118736326694489e-01" rms="7.6103711128234863e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="4" Cut="1.0848824310302734e+02" cType="1" res="1.7289973795413971e-02" rms="7.4661827087402344e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.6948910672217607e-03" rms="7.3988122940063477e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.7927335500717163e-01" rms="8.4438753128051758e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="4" Cut="1.3114694213867188e+02" cType="1" res="9.4372940063476562e-01" rms="8.8864116668701172e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.0480762720108032e-01" rms="8.0785951614379883e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.1462350189685822e-02" rms="8.8917160034179688e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="12" Cut="3.1573548913002014e-01" cType="1" res="-2.5539617538452148e+00" rms="9.6115217208862305e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.3497648239135742e+00" rms="8.9137439727783203e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          <Node pos="r" depth="2" NCoef="0" IVar="3" Cut="2.9124838113784790e-01" cType="1" res="-9.9489974975585938e-01" rms="9.8117761611938477e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.0362434387207031e+00" rms="9.2403221130371094e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.3261671066284180e-01" rms="9.3142051696777344e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="176">
+      <Node pos="s" depth="0" NCoef="0" IVar="11" Cut="1.1488436162471771e-01" cType="1" res="1.8253616988658905e-01" rms="7.6384868621826172e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="11" Cut="1.0939045809209347e-02" cType="1" res="3.2016925513744354e-02" rms="7.5654191970825195e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="7" Cut="-7.9880393981933594e+01" cType="1" res="-2.3271366953849792e-01" rms="7.3049402236938477e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.7120825648307800e-02" rms="6.9754085540771484e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.3578229844570160e-02" rms="7.9880566596984863e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="8.8633906841278076e-01" cType="1" res="2.2519297897815704e-01" rms="7.7442603111267090e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2601675465703011e-02" rms="7.7465100288391113e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.2982361316680908e-01" rms="7.2853832244873047e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="12" Cut="1.2433390319347382e-01" cType="1" res="6.3929355144500732e-01" rms="7.8383822441101074e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="7.9319113492965698e-01" cType="1" res="-4.1333171725273132e-01" rms="7.7979741096496582e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.2475837022066116e-01" rms="7.7141628265380859e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0264613628387451e+00" rms="6.8418922424316406e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="7.1515995264053345e-01" cType="1" res="8.3275038003921509e-01" rms="7.8304080963134766e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.8339200019836426e-02" rms="7.8300390243530273e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.2083466053009033e-01" rms="6.3032770156860352e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="177">
+      <Node pos="s" depth="0" NCoef="0" IVar="11" Cut="1.5317913889884949e-01" cType="1" res="1.0898461937904358e-01" rms="7.6554160118103027e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="13" Cut="1.0428571701049805e+01" cType="1" res="1.2496155686676502e-02" rms="7.5916390419006348e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="13" Cut="9.2380952835083008e+00" cType="1" res="4.4039696455001831e-01" rms="7.3443593978881836e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4443461550399661e-03" rms="7.2884807586669922e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2917341291904449e-01" rms="7.4038457870483398e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="6.3422638177871704e-01" cType="1" res="-9.2558309435844421e-02" rms="7.6474671363830566e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.9945245981216431e-02" rms="7.8974623680114746e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.6887860409915447e-03" rms="7.3858027458190918e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="10" Cut="7.1082377433776855e-01" cType="1" res="5.5570763349533081e-01" rms="7.9287343025207520e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="12" Cut="3.7300169467926025e-01" cType="1" res="3.9346006512641907e-01" rms="7.9063658714294434e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3173477724194527e-02" rms="7.9226741790771484e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.8362230062484741e-01" rms="7.7744445800781250e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="4" Cut="5.9532646179199219e+01" cType="1" res="5.3392143249511719e+00" rms="7.0462732315063477e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2763466835021973e+00" rms="5.8223881721496582e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.7525074481964111e-01" rms="8.1697502136230469e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="178">
+      <Node pos="s" depth="0" NCoef="0" IVar="5" Cut="9.3953659057617188e+01" cType="1" res="1.7771078646183014e-01" rms="7.6121768951416016e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="5" Cut="5.2553081512451172e+01" cType="1" res="1.8981239199638367e-01" rms="7.6043610572814941e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="1.0117436981201172e+02" cType="1" res="1.6294570267200470e-01" rms="7.5695328712463379e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.9933376461267471e-02" rms="7.3355531692504883e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.0398370027542114e-01" rms="8.7913017272949219e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="8.6309283971786499e-01" cType="1" res="1.7154959440231323e+00" rms="9.2449026107788086e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.9673779010772705e-01" rms="9.4166069030761719e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1070195436477661e+00" rms="7.1261391639709473e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.2793858051300049e-01" rms="8.9750156402587891e+00" purity="1.0000000000000000e+00" nType="-99"/>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="179">
+      <Node pos="s" depth="0" NCoef="0" IVar="1" Cut="4.2107812500000000e+02" cType="1" res="5.0925202667713165e-02" rms="7.5923686027526855e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="0" Cut="3.2030349731445312e+02" cType="1" res="3.8492638617753983e-02" rms="7.5839724540710449e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="12" Cut="5.0910294055938721e-01" cType="1" res="4.9359422177076340e-02" rms="7.5762414932250977e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.6247415915131569e-02" rms="7.5586247444152832e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.3859343528747559e-02" rms="7.7107667922973633e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.5707151889801025e-01" rms="9.1228427886962891e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.2419009208679199e+00" rms="9.1556968688964844e+00" purity="1.0000000000000000e+00" nType="-99"/>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="180">
+      <Node pos="s" depth="0" NCoef="0" IVar="12" Cut="2.2946278750896454e-01" cType="1" res="1.1051695793867111e-01" rms="7.6238832473754883e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="10" Cut="8.2693111896514893e-01" cType="1" res="-9.9915407598018646e-02" rms="7.5054101943969727e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="6" Cut="-9.3420959472656250e+01" cType="1" res="-2.4230453372001648e-01" rms="7.6088700294494629e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.8257245719432831e-02" rms="7.2172875404357910e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1240852065384388e-02" rms="8.1080074310302734e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="1.7344178259372711e-01" cType="1" res="4.0027201175689697e-01" rms="7.1075100898742676e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.7933949828147888e-02" rms="7.0688514709472656e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.0397268533706665e-01" rms="4.0559654235839844e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="10" Cut="7.3245954513549805e-01" cType="1" res="2.4595981836318970e-01" rms="7.6961307525634766e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="15" Cut="1.7839196920394897e+00" cType="1" res="1.3843211531639099e-01" rms="7.7283277511596680e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.0683636888861656e-02" rms="7.7199168205261230e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.0273835062980652e-01" rms="7.7387347221374512e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="1.1788967065513134e-02" cType="1" res="2.1740143299102783e+00" rms="6.8118228912353516e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.2419952154159546e-02" rms="6.6097602844238281e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.5218217372894287e-01" rms="5.7945604324340820e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="181">
+      <Node pos="s" depth="0" NCoef="0" IVar="12" Cut="1.3884626328945160e-01" cType="1" res="6.7287310957908630e-02" rms="7.5869584083557129e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="6" Cut="1.6323330402374268e+00" cType="1" res="-4.5179238915443420e-01" rms="7.4809141159057617e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="5" Cut="3.9248512268066406e+01" cType="1" res="-2.8774631023406982e-01" rms="7.4536447525024414e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.1512900292873383e-02" rms="7.2755522727966309e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4663673937320709e-01" rms="8.7479372024536133e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="6.7170310020446777e-01" cType="1" res="-2.4896240234375000e+00" rms="7.5190477371215820e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.5988881587982178e-01" rms="7.2150764465332031e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.2355451285839081e-02" rms="8.1606283187866211e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="15" Cut="3.2521679401397705e+00" cType="1" res="1.7255303263664246e-01" rms="7.6039628982543945e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="6.5557760000228882e-01" cType="1" res="2.1015802025794983e-01" rms="7.6005368232727051e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.3343088626861572e-03" rms="7.7798314094543457e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.3573025166988373e-02" rms="7.1432156562805176e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="3" Cut="-1.4523116350173950e+00" cType="1" res="-1.4167468547821045e+00" rms="7.5786776542663574e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.7095043659210205e-01" rms="6.9949207305908203e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.5833407044410706e-01" rms="7.5446181297302246e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="182">
+      <Node pos="s" depth="0" NCoef="0" IVar="15" Cut="2.9731996059417725e+00" cType="1" res="9.6724912524223328e-02" rms="7.6016168594360352e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="1" Cut="9.4960037231445312e+01" cType="1" res="1.4171130955219269e-01" rms="7.6221642494201660e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="4" Cut="9.5467941284179688e+01" cType="1" res="4.4790521264076233e-02" rms="7.3337130546569824e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.1972658149898052e-03" rms="7.3238959312438965e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.3611274957656860e-01" rms="7.3964452743530273e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="0" Cut="1.1262494659423828e+02" cType="1" res="5.6620633602142334e-01" rms="8.7618923187255859e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.2669740021228790e-01" rms="8.4858942031860352e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.1293202191591263e-02" rms="8.8819942474365234e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="12" Cut="3.8545924425125122e-01" cType="1" res="-7.4974477291107178e-01" rms="7.1515092849731445e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="5.3293377161026001e-02" cType="1" res="-9.4116950035095215e-01" rms="7.1040606498718262e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.1533676683902740e-02" rms="6.9876818656921387e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.0293029546737671e-01" rms="7.2035379409790039e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.3498214483261108e-01" rms="6.8435888290405273e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="183">
+      <Node pos="s" depth="0" NCoef="0" IVar="12" Cut="8.9288175106048584e-02" cType="1" res="1.3848075270652771e-01" rms="7.6491117477416992e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="17" Cut="5.3333334922790527e+00" cType="1" res="-7.1734970808029175e-01" rms="7.5400376319885254e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="2" Cut="2.7371925354003906e+01" cType="1" res="-8.6545997858047485e-01" rms="7.5461773872375488e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.5776650607585907e-01" rms="7.5419397354125977e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.5648939609527588e-01" rms="7.0757241249084473e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="0" Cut="7.3291061401367188e+01" cType="1" res="1.8290753364562988e+00" rms="6.9568796157836914e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.0910702198743820e-02" rms="5.7698159217834473e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.4816099405288696e-01" rms="7.7204051017761230e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="10" Cut="9.0930932760238647e-01" cType="1" res="2.0845985412597656e-01" rms="7.6537308692932129e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="3.6068066954612732e-02" cType="1" res="1.8368639051914215e-01" rms="7.6515035629272461e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.4365982264280319e-02" rms="7.4654803276062012e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.4756665825843811e-02" rms="7.8133077621459961e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="3" Cut="-1.1161769926548004e-01" cType="1" res="5.6300139427185059e+00" rms="6.0425119400024414e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.1809310913085938e-01" rms="6.7561740875244141e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.6825042963027954e+00" rms="4.6903152465820312e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="184">
+      <Node pos="s" depth="0" NCoef="0" IVar="11" Cut="3.7103155255317688e-01" cType="1" res="6.4739264547824860e-02" rms="7.5751280784606934e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="2" Cut="3.3537593841552734e+01" cType="1" res="2.7368431910872459e-02" rms="7.5625972747802734e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="4.3888181447982788e-02" cType="1" res="4.2537137866020203e-02" rms="7.5575332641601562e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.8979912623763084e-02" rms="7.4941072463989258e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.5894169956445694e-02" rms="7.8790216445922852e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="15" Cut="5.6876760721206665e-01" cType="1" res="-1.7132176160812378e+00" rms="7.9324293136596680e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.0202372074127197e-01" rms="6.6650919914245605e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.3949739336967468e-02" rms="8.1762800216674805e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="16" Cut="1.8725838661193848e+00" cType="1" res="1.3232377767562866e+00" rms="7.8828601837158203e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="13" Cut="1.4333333015441895e+01" cType="1" res="1.7323873043060303e+00" rms="7.9924626350402832e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.5991623997688293e-01" rms="7.9566082954406738e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.4745455980300903e-01" rms="7.5810756683349609e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.6368644833564758e-01" rms="5.5738000869750977e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="185">
+      <Node pos="s" depth="0" NCoef="0" IVar="12" Cut="2.7706283330917358e-01" cType="1" res="1.1100085824728012e-01" rms="7.5785269737243652e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="0" Cut="2.6862622070312500e+02" cType="1" res="-7.4176885187625885e-02" rms="7.4949913024902344e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="9.4667261838912964e-01" cType="1" res="-5.4317764937877655e-02" rms="7.4813485145568848e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.7196450158953667e-02" rms="7.4730663299560547e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.3775123953819275e-01" rms="7.6580867767333984e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.3630520105361938e+00" rms="9.0302371978759766e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="10" Cut="6.8815958499908447e-01" cType="1" res="3.0498847365379333e-01" rms="7.6602606773376465e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="6.1804097145795822e-02" cType="1" res="1.6777083277702332e-01" rms="7.6777663230895996e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.1009865440428257e-02" rms="7.6596107482910156e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4823083579540253e-01" rms="7.7647514343261719e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="3.1314775347709656e-01" cType="1" res="2.4078490734100342e+00" rms="7.0607528686523438e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.4441264867782593e-02" rms="6.8452434539794922e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3319923877716064e+00" rms="5.3581194877624512e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="186">
+      <Node pos="s" depth="0" NCoef="0" IVar="10" Cut="9.7803354263305664e-01" cType="1" res="8.4300257265567780e-02" rms="7.5941319465637207e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="7" Cut="-7.9208786010742188e+01" cType="1" res="7.4402607977390289e-02" rms="7.5903005599975586e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="5.1745706796646118e-01" cType="1" res="-4.2289234697818756e-02" rms="7.3823790550231934e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.0420089215040207e-01" rms="7.7349390983581543e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4779693447053432e-02" rms="7.2109780311584473e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="3" Cut="-1.4851590394973755e+00" cType="1" res="3.8178032636642456e-01" rms="8.1044816970825195e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.3892116546630859e-01" rms="8.0000600814819336e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7055269330739975e-02" rms="8.1070566177368164e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4217343330383301e+00" rms="7.9694776535034180e+00" purity="1.0000000000000000e+00" nType="-99"/>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="187">
+      <Node pos="s" depth="0" NCoef="0" IVar="10" Cut="4.9055051803588867e-01" cType="1" res="6.1226479709148407e-02" rms="7.5649056434631348e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="5" Cut="1.6321172714233398e+01" cType="1" res="-2.4532397091388702e-01" rms="7.8448162078857422e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="12" Cut="5.5071067810058594e-01" cType="1" res="-4.9846628308296204e-01" rms="7.5998773574829102e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.1772431433200836e-01" rms="7.5936632156372070e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0430810973048210e-02" rms="7.5706591606140137e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="13" Cut="5.4285712242126465e+00" cType="1" res="3.3186048269271851e-01" rms="8.3479003906250000e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.2378010749816895e-01" rms="7.1914744377136230e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.9353277087211609e-02" rms="8.3503379821777344e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="12" Cut="5.1555585861206055e-01" cType="1" res="2.1119879186153412e-01" rms="7.4195103645324707e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="12" Cut="4.4188293814659119e-01" cType="1" res="1.8291260302066803e-01" rms="7.4120378494262695e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.3065277598798275e-03" rms="7.4163379669189453e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.3158773779869080e-01" rms="7.1280384063720703e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.8146713972091675e+00" rms="4.9301772117614746e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="188">
+      <Node pos="s" depth="0" NCoef="0" IVar="15" Cut="1.8188889026641846e+00" cType="1" res="9.3207485973834991e-02" rms="7.5697369575500488e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="2" Cut="3.2297348022460938e+01" cType="1" res="2.0496097207069397e-01" rms="7.6190171241760254e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="12" Cut="8.2606601715087891e-01" cType="1" res="2.4733760952949524e-01" rms="7.6102252006530762e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7475564032793045e-02" rms="7.6044387817382812e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.0265798568725586e-01" rms="8.1326313018798828e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="17" Cut="2.1428570747375488e+00" cType="1" res="-2.4925606250762939e+00" rms="7.6929430961608887e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.3335273265838623e-01" rms="7.3030428886413574e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.9293017238378525e-02" rms="7.9337005615234375e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="5" Cut="5.5312500000000000e+01" cType="1" res="-3.5296830534934998e-01" rms="7.3527946472167969e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="7" Cut="1.4652292251586914e+01" cType="1" res="-2.8692907094955444e-01" rms="7.3012986183166504e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.7024124562740326e-02" rms="7.0894851684570312e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3409864902496338e-01" rms="8.4249010086059570e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="16" Cut="1.1556937694549561e+00" cType="1" res="-3.1582012176513672e+00" rms="8.8353967666625977e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.8760647177696228e-01" rms="8.9528541564941406e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.3840932846069336e-01" rms="8.4642534255981445e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="189">
+      <Node pos="s" depth="0" NCoef="0" IVar="11" Cut="2.2976872324943542e-01" cType="1" res="1.6141855716705322e-01" rms="7.5918421745300293e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="10" Cut="3.7921792268753052e-01" cType="1" res="8.4464438259601593e-02" rms="7.5476307868957520e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="1.2676805877685547e+02" cType="1" res="-4.1676786541938782e-01" rms="7.9880743026733398e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.2162432819604874e-02" rms="7.9090495109558105e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.4882231950759888e-01" rms="8.7467136383056641e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="5.8301919698715210e-01" cType="1" res="1.6847307980060577e-01" rms="7.4679794311523438e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.4065066613256931e-03" rms="7.4613165855407715e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.6394205093383789e-01" rms="7.4886851310729980e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="10" Cut="6.4782923460006714e-01" cType="1" res="9.1551935672760010e-01" rms="7.9729814529418945e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="16" Cut="1.8725838661193848e+00" cType="1" res="7.8975284099578857e-01" rms="7.9818916320800781e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3699346780776978e-01" rms="7.9884343147277832e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.1919764429330826e-01" rms="7.7327070236206055e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.9814156293869019e-01" rms="5.1912016868591309e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="190">
+      <Node pos="s" depth="0" NCoef="0" IVar="17" Cut="3.3333332538604736e+00" cType="1" res="1.1170236766338348e-01" rms="7.5561695098876953e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="16" Cut="2.7903165817260742e+00" cType="1" res="7.5717098079621792e-03" rms="7.6131358146667480e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="-1.7144964933395386e+00" cType="1" res="-3.7617646157741547e-02" rms="7.5896315574645996e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.1504604667425156e-01" rms="7.1652636528015137e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.0895358696579933e-03" rms="7.6271572113037109e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="6" Cut="-9.4014785766601562e+01" cType="1" res="1.0275508165359497e+00" rms="8.0584611892700195e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4163129962980747e-02" rms="7.9132046699523926e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.3780893087387085e-01" rms="8.0937252044677734e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="5" Cut="4.0471725463867188e+01" cType="1" res="5.8611041307449341e-01" rms="7.2721595764160156e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="12" Cut="4.7460690140724182e-01" cType="1" res="7.2733813524246216e-01" rms="7.1854820251464844e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.0681147277355194e-02" rms="7.1647462844848633e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.1645992398262024e-01" rms="7.4073181152343750e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="2" Cut="1.8440511703491211e+01" cType="1" res="-2.6922557353973389e+00" rms="8.4120998382568359e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.6479218006134033e-01" rms="7.6870679855346680e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.0732554197311401e-01" rms="8.9953670501708984e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="191">
+      <Node pos="s" depth="0" NCoef="0" IVar="12" Cut="7.8679549694061279e-01" cType="1" res="5.9837378561496735e-02" rms="7.5351104736328125e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="12" Cut="2.9880386590957642e-01" cType="1" res="4.7652650624513626e-02" rms="7.5310502052307129e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="7.6768696308135986e-01" cType="1" res="-9.4412840902805328e-02" rms="7.4587149620056152e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.5008668452501297e-02" rms="7.6336178779602051e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.2629009559750557e-02" rms="6.9728946685791016e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="7.1219080686569214e-01" cType="1" res="2.3715645074844360e-01" rms="7.6223511695861816e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3419058173894882e-02" rms="7.6139478683471680e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.5868170261383057e-01" rms="6.2860856056213379e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="10" Cut="1.5420481562614441e-01" cType="1" res="2.8851358890533447e+00" rms="7.9338202476501465e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.3461577948182821e-03" rms="8.2350187301635742e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.6356776952743530e-01" rms="6.7892756462097168e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="192">
+      <Node pos="s" depth="0" NCoef="0" IVar="12" Cut="4.6282086521387100e-02" cType="1" res="1.5972498059272766e-01" rms="7.5293979644775391e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="12" Cut="1.7572863027453423e-02" cType="1" res="-1.1209180355072021e+00" rms="7.2125644683837891e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="15" Cut="1.4231848716735840e+00" cType="1" res="-3.0010418891906738e+00" rms="6.9662475585937500e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.7756092548370361e-01" rms="7.4282560348510742e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.6304931640625000e-01" rms="5.6842031478881836e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="3.6806331634521484e+01" cType="1" res="-5.8933538198471069e-01" rms="7.1921153068542480e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.9892890453338623e-01" rms="7.3658924102783203e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.8239678144454956e-03" rms="6.9864678382873535e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="17" Cut="3.3333332538604736e+00" cType="1" res="1.8795520067214966e-01" rms="7.5337800979614258e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="-1.9428546428680420e+00" cType="1" res="1.0071893781423569e-01" rms="7.5846714973449707e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.9172760248184204e-02" rms="7.4287438392639160e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.0340729542076588e-03" rms="7.5930910110473633e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="13" Cut="9.0000000000000000e+00" cType="1" res="5.8860319852828979e-01" rms="7.2820854187011719e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.8017726540565491e-01" rms="7.3137636184692383e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.9784164875745773e-02" rms="7.2681980133056641e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="193">
+      <Node pos="s" depth="0" NCoef="0" IVar="11" Cut="3.7706431746482849e-01" cType="1" res="1.6006401181221008e-01" rms="7.5136685371398926e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="10" Cut="5.0136631727218628e-01" cType="1" res="1.2804125249385834e-01" rms="7.4953217506408691e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="6" Cut="-9.3305648803710938e+01" cType="1" res="-1.5962393581867218e-01" rms="7.7742409706115723e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.2287669181823730e-02" rms="7.5231704711914062e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.2507866621017456e-02" rms="8.0593366622924805e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="4.9711853265762329e-01" cType="1" res="2.7232158184051514e-01" rms="7.3472042083740234e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3541765511035919e-02" rms="7.3448467254638672e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.1562849283218384e-01" rms="4.4649329185485840e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="1" Cut="4.1680816650390625e+01" cType="1" res="1.3157467842102051e+00" rms="8.0635166168212891e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="1.4422372579574585e+00" cType="1" res="-1.0257250070571899e+00" rms="7.2588090896606445e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.6203411817550659e-01" rms="7.1826519966125488e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2059250473976135e-01" rms="6.9706912040710449e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="4" Cut="4.5929946899414062e+01" cType="1" res="2.0005168914794922e+00" rms="8.1580610275268555e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.5423424243927002e-01" rms="6.5064277648925781e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.4498175084590912e-01" rms="8.2579202651977539e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="194">
+      <Node pos="s" depth="0" NCoef="0" IVar="10" Cut="3.5946351289749146e-01" cType="1" res="7.6763577759265900e-02" rms="7.5358886718750000e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="3" Cut="-1.4848090410232544e+00" cType="1" res="-3.1776440143585205e-01" rms="7.9882469177246094e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="4" Cut="1.1752693176269531e+02" cType="1" res="-1.1907775402069092e+00" rms="7.8986511230468750e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.9484033882617950e-02" rms="7.7951412200927734e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.6292916536331177e-01" rms="7.8702068328857422e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="3" Cut="1.6599843502044678e+00" cType="1" res="-1.2773504853248596e-01" rms="7.9949932098388672e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.9602566026151180e-03" rms="8.0595884323120117e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.9621507823467255e-01" rms="7.6339130401611328e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="12" Cut="6.1945790052413940e-01" cType="1" res="1.4676234126091003e-01" rms="7.4505801200866699e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="3.2700893282890320e-01" cType="1" res="1.2244346737861633e-01" rms="7.4482817649841309e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.3636729717254639e-03" rms="7.4362039566040039e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.0624010562896729e-01" rms="7.8551945686340332e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.4655201435089111e-01" rms="5.5877084732055664e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="195">
+      <Node pos="s" depth="0" NCoef="0" IVar="12" Cut="9.1785110533237457e-02" cType="1" res="2.1421013399958611e-02" rms="7.5094666481018066e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="11" Cut="3.0939263105392456e-01" cType="1" res="-6.9389432668685913e-01" rms="7.5033764839172363e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="17" Cut="3.8095238804817200e-01" cType="1" res="-8.9220112562179565e-01" rms="7.4705710411071777e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.9080477356910706e-01" rms="7.5162849426269531e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.2761726081371307e-02" rms="7.3784418106079102e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="4.5481422543525696e-01" cType="1" res="1.9317635297775269e+00" rms="7.4424409866333008e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.9901022911071777e-01" rms="6.8468728065490723e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.2742283344268799e-02" rms="7.4288954734802246e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="10" Cut="8.7020808458328247e-01" cType="1" res="7.7789112925529480e-02" rms="7.5070495605468750e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="3.5868696868419647e-02" cType="1" res="3.2805841416120529e-02" rms="7.5142545700073242e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.3025531321763992e-02" rms="7.4771618843078613e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.2089353799819946e-02" rms="7.6947889328002930e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="7.9690469428896904e-03" cType="1" res="2.3943018913269043e+00" rms="6.7314057350158691e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3755390048027039e-01" rms="6.5382094383239746e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1129853725433350e+00" rms="5.5633358955383301e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="196">
+      <Node pos="s" depth="0" NCoef="0" IVar="12" Cut="1.8221943080425262e-01" cType="1" res="1.0085730254650116e-01" rms="7.5451021194458008e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="5" Cut="8.2965171813964844e+01" cType="1" res="-1.9070252776145935e-01" rms="7.4044094085693359e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="8.9056509733200073e-01" cType="1" res="-1.6568142175674438e-01" rms="7.3825755119323730e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.4475769400596619e-02" rms="7.4071178436279297e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.4102932810783386e-02" rms="7.1667580604553223e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.1126347780227661e+00" rms="9.2541475296020508e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="10" Cut="8.1639552116394043e-01" cType="1" res="2.1026930212974548e-01" rms="7.5943388938903809e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="13" Cut="2.4000000000000000e+01" cType="1" res="1.5219245851039886e-01" rms="7.5907955169677734e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.1277973428368568e-03" rms="7.5534191131591797e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.1653836965560913e-01" rms="8.6143150329589844e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="5.1526927947998047e+01" cType="1" res="5.6447639465332031e+00" rms="5.7323546409606934e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.6018745899200439e-01" rms="5.9355196952819824e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3980373144149780e+00" rms="4.7618651390075684e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="197">
+      <Node pos="s" depth="0" NCoef="0" IVar="11" Cut="3.0939263105392456e-01" cType="1" res="-1.4108238974586129e-03" rms="7.5613050460815430e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="10" Cut="5.3646153211593628e-01" cType="1" res="-4.7267094254493713e-02" rms="7.5388979911804199e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="5" Cut="1.6118070602416992e+01" cType="1" res="-2.9378280043601990e-01" rms="7.7941589355468750e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.3785414695739746e-02" rms="7.4882912635803223e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.6025960221886635e-02" rms="8.4199256896972656e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="4.2825320363044739e-01" cType="1" res="1.0785005986690521e-01" rms="7.3695240020751953e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.3589120469987392e-02" rms="7.3647513389587402e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.9975425601005554e-01" rms="6.9737596511840820e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="10" Cut="2.3582483828067780e-01" cType="1" res="9.0923851728439331e-01" rms="7.9386105537414551e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="5" Cut="7.5525946617126465e+00" cType="1" res="-3.8480871915817261e-01" rms="8.1343078613281250e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.4675762653350830e-01" rms="7.6134567260742188e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.1300925314426422e-01" rms="8.4758110046386719e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="3.3133733272552490e-01" cType="1" res="1.5323719978332520e+00" rms="7.7660951614379883e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.6394871473312378e-01" rms="7.7527823448181152e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.0605169534683228e-01" rms="6.8777642250061035e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="198">
+      <Node pos="s" depth="0" NCoef="0" IVar="11" Cut="1.5469631552696228e-01" cType="1" res="1.0037863254547119e-01" rms="7.5563960075378418e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="10" Cut="7.7601015567779541e-01" cType="1" res="1.8459119601175189e-03" rms="7.4769587516784668e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="-1.2570499181747437e+00" cType="1" res="-1.1151200532913208e-01" rms="7.5593390464782715e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.9432519823312759e-02" rms="7.5844922065734863e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.6824987977743149e-02" rms="7.5486588478088379e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="2.3198865354061127e-01" cType="1" res="5.1732850074768066e-01" rms="7.0673866271972656e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.1405385583639145e-02" rms="7.0236449241638184e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0213164091110229e+00" rms="6.4797229766845703e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="3" Cut="1.9421727657318115e+00" cType="1" res="5.8308768272399902e-01" rms="7.9163703918457031e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="-1.9865525960922241e+00" cType="1" res="7.4137616157531738e-01" rms="7.9535455703735352e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.4949184656143188e-02" rms="7.9027295112609863e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2097950279712677e-01" rms="7.9482645988464355e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="5.1726990938186646e-01" cType="1" res="-9.1699993610382080e-01" rms="7.3885126113891602e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.3211953043937683e-01" rms="7.3384447097778320e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.5486388206481934e-01" rms="6.3348927497863770e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="199">
+      <Node pos="s" depth="0" NCoef="0" IVar="11" Cut="5.5022138357162476e-01" cType="1" res="1.1051318049430847e-01" rms="7.5651035308837891e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="10" Cut="5.9292322397232056e-01" cType="1" res="9.5489755272865295e-02" rms="7.5611200332641602e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="1.0465298593044281e-01" cType="1" res="-8.4076888859272003e-02" rms="7.7891793251037598e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.6743938475847244e-02" rms="7.7581148147583008e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.7112120762467384e-02" rms="7.8262300491333008e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="4.0571305155754089e-01" cType="1" res="2.8376966714859009e-01" rms="7.3096256256103516e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1090318672358990e-02" rms="7.2973642349243164e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0530979633331299e+00" rms="4.7723121643066406e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="5" Cut="6.0867743492126465e+00" cType="1" res="3.4955098628997803e+00" rms="7.7005043029785156e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.1279388070106506e-01" rms="7.5805311203002930e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.4775596857070923e-01" rms="7.5591435432434082e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+  </Weights>
+</MethodSetup>

--- a/JetEnergyRegression/weights/new-weights-23Jan.xml
+++ b/JetEnergyRegression/weights/new-weights-23Jan.xml
@@ -1,0 +1,4524 @@
+<?xml version="1.0"?>
+<MethodSetup Method="BDT::BDTG">
+  <GeneralInfo>
+    <Info name="TMVA Release" value="4.2.0 [262656]"/>
+    <Info name="ROOT Release" value="5.34/20 [336404]"/>
+    <Info name="Creator" value="cvernier"/>
+    <Info name="Date" value="Thu Jan 22 05:21:25 2015"/>
+    <Info name="Host" value="Linux buildvm-13.phx2.fedoraproject.org 3.15.6-200.fc20.x86_64 #1 SMP Fri Jul 18 02:36:27 UTC 2014 x86_64 x86_64 x86_64 GNU/Linux"/>
+    <Info name="Dir" value="/afs/cern.ch/work/c/cvernier/testRegression/CMSSW_7_1_4/src/Phys14-Optimization"/>
+    <Info name="Training events" value="20626"/>
+    <Info name="TrainingTime" value="5.49968815e+00"/>
+    <Info name="AnalysisType" value="Regression"/>
+  </GeneralInfo>
+  <Options>
+    <Option name="V" modified="Yes">False</Option>
+    <Option name="VerbosityLevel" modified="No">Default</Option>
+    <Option name="VarTransform" modified="No">None</Option>
+    <Option name="H" modified="Yes">False</Option>
+    <Option name="CreateMVAPdfs" modified="No">False</Option>
+    <Option name="IgnoreNegWeightsInTraining" modified="No">False</Option>
+    <Option name="NTrees" modified="Yes">200</Option>
+    <Option name="MaxDepth" modified="Yes">3</Option>
+    <Option name="MinNodeSize" modified="No">0.2%</Option>
+    <Option name="nCuts" modified="Yes">20</Option>
+    <Option name="BoostType" modified="Yes">Grad</Option>
+    <Option name="AdaBoostR2Loss" modified="No">quadratic</Option>
+    <Option name="UseBaggedBoost" modified="No">True</Option>
+    <Option name="Shrinkage" modified="Yes">1.000000e-01</Option>
+    <Option name="AdaBoostBeta" modified="No">5.000000e-01</Option>
+    <Option name="UseRandomisedTrees" modified="No">False</Option>
+    <Option name="UseNvars" modified="No">4</Option>
+    <Option name="UsePoissonNvars" modified="No">True</Option>
+    <Option name="BaggedSampleFraction" modified="No">5.000000e-01</Option>
+    <Option name="UseYesNoLeaf" modified="No">False</Option>
+    <Option name="NegWeightTreatment" modified="No">ignorenegweightsintraining</Option>
+    <Option name="Css" modified="No">1.000000e+00</Option>
+    <Option name="Cts_sb" modified="No">1.000000e+00</Option>
+    <Option name="Ctb_ss" modified="No">1.000000e+00</Option>
+    <Option name="Cbb" modified="No">1.000000e+00</Option>
+    <Option name="NodePurityLimit" modified="No">5.000000e-01</Option>
+    <Option name="SeparationType" modified="No">regressionvariance</Option>
+    <Option name="DoBoostMonitor" modified="No">False</Option>
+    <Option name="UseFisherCuts" modified="No">False</Option>
+    <Option name="MinLinCorrForFisher" modified="No">8.000000e-01</Option>
+    <Option name="UseExclusiveVars" modified="No">False</Option>
+    <Option name="DoPreselection" modified="No">False</Option>
+    <Option name="SigToBkgFraction" modified="No">1.000000e+00</Option>
+    <Option name="PruneMethod" modified="Yes">costcomplexity</Option>
+    <Option name="PruneStrength" modified="Yes">3.000000e+01</Option>
+    <Option name="PruningValFraction" modified="No">5.000000e-01</Option>
+    <Option name="nEventsMin" modified="No">0</Option>
+    <Option name="UseBaggedGrad" modified="Yes">True</Option>
+    <Option name="GradBaggingFraction" modified="Yes">5.000000e-01</Option>
+    <Option name="UseNTrainEvents" modified="No">0</Option>
+    <Option name="NNodesMax" modified="No">0</Option>
+  </Options>
+  <Variables NVar="17">
+    <Variable VarIndex="0" Expression="Jet_pt" Label="Jet_pt" Title="Jet_pt" Unit="units" Internal="Jet_pt" Type="F" Min="2.50011120e+01" Max="1.19257239e+03"/>
+    <Variable VarIndex="1" Expression="rho" Label="rho" Title="rho" Unit="units" Internal="rho" Type="F" Min="4.87970877e+00" Max="4.64544601e+01"/>
+    <Variable VarIndex="2" Expression="Jet_eta" Label="Jet_eta" Title="Jet_eta" Unit="units" Internal="Jet_eta" Type="F" Min="-2.39993119e+00" Max="2.39946342e+00"/>
+    <Variable VarIndex="3" Expression="Jet_mt" Label="Jet_mt" Title="Jet_mt" Unit="units" Internal="Jet_mt" Type="F" Min="2.53279552e+01" Max="1.19931213e+03"/>
+    <Variable VarIndex="4" Expression="Jet_leadTrackPt" Label="Jet_leadTrackPt" Title="Jet_leadTrackPt  " Unit="units" Internal="Jet_leadTrackPt" Type="F" Min="4.33349609e-01" Max="5.92000000e+02"/>
+    <Variable VarIndex="5" Expression="Jet_leptonPtRel" Label="Jet_leptonPtRel" Title="Jet_leptonPtRel" Unit="units" Internal="Jet_leptonPtRel" Type="F" Min="-9.90000000e+01" Max="1.32485065e+01"/>
+    <Variable VarIndex="6" Expression="Jet_leptonPt" Label="Jet_leptonPt" Title="Jet_leptonPt" Unit="units" Internal="Jet_leptonPt" Type="F" Min="-9.90000000e+01" Max="4.64607178e+02"/>
+    <Variable VarIndex="7" Expression="Jet_leptonDeltaR" Label="Jet_leptonDeltaR" Title="Jet_leptonDeltaR" Unit="units" Internal="Jet_leptonDeltaR" Type="F" Min="-9.90000000e+01" Max="3.85484427e-01"/>
+    <Variable VarIndex="8" Expression="Jet_chEmEF" Label="Jet_chEmEF" Title="Jet_chEmEF " Unit="units" Internal="Jet_chEmEF" Type="F" Min="0.00000000e+00" Max="8.22091818e-01"/>
+    <Variable VarIndex="9" Expression="Jet_chHEF" Label="Jet_chHEF" Title="Jet_chHEF" Unit="units" Internal="Jet_chHEF" Type="F" Min="1.10916412e-02" Max="1.17609859e+00"/>
+    <Variable VarIndex="10" Expression="Jet_neHEF" Label="Jet_neHEF" Title="Jet_neHEF" Unit="units" Internal="Jet_neHEF" Type="F" Min="0.00000000e+00" Max="8.04190516e-01"/>
+    <Variable VarIndex="11" Expression="Jet_neEmEF" Label="Jet_neEmEF" Title="Jet_neEmEF" Unit="units" Internal="Jet_neEmEF" Type="F" Min="0.00000000e+00" Max="9.80398357e-01"/>
+    <Variable VarIndex="12" Expression="Jet_chMult" Label="Jet_chMult" Title="Jet_chMult" Unit="units" Internal="Jet_chMult" Type="F" Min="2.00000000e+00" Max="6.10000000e+01"/>
+    <Variable VarIndex="13" Expression="Jet_vtxPt" Label="Jet_vtxPt" Title="Jet_vtxPt" Unit="units" Internal="Jet_vtxPt" Type="F" Min="0.00000000e+00" Max="2.48267792e+02"/>
+    <Variable VarIndex="14" Expression="Jet_vtxMass" Label="Jet_vtxMass" Title="Jet_vtxMass" Unit="units" Internal="Jet_vtxMass" Type="F" Min="0.00000000e+00" Max="6.16600990e+00"/>
+    <Variable VarIndex="15" Expression="Jet_vtx3dL" Label="Jet_vtx3dL" Title="Jet_vtx3dL" Unit="units" Internal="Jet_vtx3dL" Type="F" Min="0.00000000e+00" Max="1.28987312e+01"/>
+    <Variable VarIndex="16" Expression="Jet_vtxNtrk" Label="Jet_vtxNtrk" Title="Jet_vtxNtrk" Unit="units" Internal="Jet_vtxNtrk" Type="I" Min="0.00000000e+00" Max="1.00000000e+01"/>
+  </Variables>
+  <Spectators NSpec="0"/>
+  <Classes NClass="1">
+    <Class Name="Regression" Index="0"/>
+  </Classes>
+  <Targets NTrgt="1">
+    <Target TargetIndex="0" Expression="Jet_mcPt" Label="Jet_mcPt" Title="Jet_mcPt" Unit="" Internal="Jet_mcPt" Type="F" Min="1.00026970e+01" Max="1.17689050e+03"/>
+  </Targets>
+  <Transformations NTransformations="0"/>
+  <MVAPdfs/>
+  <Weights NTrees="200" AnalysisType="1">
+    <BinaryTree type="DecisionTree" boostWeight="6.5067260742187500e+01" itree="0">
+      <Node pos="s" depth="0" NCoef="0" IVar="3" Cut="7.1259452819824219e+01" cType="1" res="2.0005183219909668e+00" rms="2.3604623794555664e+01" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="0" Cut="4.6717136383056641e+01" cType="1" res="-1.1779258728027344e+01" rms="1.6689304351806641e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="3.6376564025878906e+01" cType="1" res="-2.0807035446166992e+01" rms="1.2645340919494629e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.7401278018951416e+00" rms="1.1006449699401855e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.6752827167510986e+00" rms="1.2596219062805176e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="0" Cut="5.6955486297607422e+01" cType="1" res="-7.7233898639678955e-01" rms="1.4235431671142578e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.6178900003433228e-01" rms="1.3106904029846191e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.0339382886886597e-01" rms="1.3053749084472656e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="0" Cut="1.1339320373535156e+02" cType="1" res="2.6592517852783203e+01" rms="1.0527222633361816e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="8.4422447204589844e+01" cType="1" res="2.3242858886718750e+01" rms="1.1533746719360352e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7947949171066284e+00" rms="1.1752338409423828e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.9119105339050293e+00" rms="7.5392661094665527e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="2" Cut="2.1709849834442139e+00" cType="1" res="3.3125278472900391e+01" rms="1.7196582555770874e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.9210386276245117e+00" rms="2.4729156494140625e-01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.2527961730957031e+00" rms="1.0100585937500000e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="1">
+      <Node pos="s" depth="0" NCoef="0" IVar="3" Cut="8.1280044555664062e+01" cType="1" res="4.8535156250000000e+01" rms="5.9971397399902344e+01" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="0" Cut="4.8951210021972656e+01" cType="1" res="3.1041053771972656e+01" rms="3.7007934570312500e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="3.6404651641845703e+01" cType="1" res="1.9351108551025391e+01" rms="3.3572551727294922e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.4780969619750977e+00" rms="3.2296634674072266e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.3599643707275391e+00" rms="3.3969532012939453e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="0" Cut="6.2640712738037109e+01" cType="1" res="4.4131832122802734e+01" rms="3.6286571502685547e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.5170940160751343e-01" rms="3.4978824615478516e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1049407720565796e+00" rms="3.6582443237304688e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="3" Cut="1.8777862548828125e+02" cType="1" res="9.4362815856933594e+01" rms="8.0799102783203125e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="1.0966783142089844e+02" cType="1" res="8.2520835876464844e+01" rms="5.4569442749023438e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.1480660438537598e+00" rms="4.1524486541748047e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.9804415702819824e+00" rms="6.4365898132324219e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="0" Cut="4.2602194213867188e+02" cType="1" res="1.8081944274902344e+02" rms="1.5476718139648438e+02" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.6967931747436523e+01" rms="1.1987617492675781e+02" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.1262683868408203e+01" rms="3.3216775512695312e+02" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="2">
+      <Node pos="s" depth="0" NCoef="0" IVar="3" Cut="1.0234742736816406e+02" cType="1" res="2.9997426986694336e+01" rms="5.3864971160888672e+01" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="0" Cut="5.7922771453857422e+01" cType="1" res="1.9683822631835938e+01" rms="3.7965843200683594e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="4.0677555084228516e+01" cType="1" res="8.8052053451538086e+00" rms="3.3670246124267578e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.0412685871124268e+00" rms="3.1599956512451172e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.7874159812927246e-01" rms="3.4241294860839844e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="0" Cut="8.0924125671386719e+01" cType="1" res="3.7087650299072266e+01" rms="3.7966808319091797e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.0162125825881958e-01" rms="3.5850028991699219e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.6234440803527832e+00" rms="3.9039859771728516e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="3" Cut="2.4142201232910156e+02" cType="1" res="8.1607231140136719e+01" rms="8.3735565185546875e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="1.3533642578125000e+02" cType="1" res="7.4747367858886719e+01" rms="6.3919685363769531e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.5437202453613281e+00" rms="4.7697959899902344e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.6368227005004883e+00" rms="7.7075538635253906e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="0" Cut="4.0706195068359375e+02" cType="1" res="1.5881713867187500e+02" rms="1.8290098571777344e+02" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.1671129226684570e+01" rms="1.4545692443847656e+02" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.6241889953613281e+01" rms="2.8338238525390625e+02" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="3">
+      <Node pos="s" depth="0" NCoef="0" IVar="0" Cut="8.0611045837402344e+01" cType="1" res="1.7905031204223633e+01" rms="4.3427639007568359e+01" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="0" Cut="5.1485260009765625e+01" cType="1" res="6.5089354515075684e+00" rms="3.0959417343139648e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="3.5096511840820312e+01" cType="1" res="-2.2086548805236816e+00" rms="2.7615358352661133e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.1205365657806396e+00" rms="2.5547946929931641e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.1053535938262939e+00" rms="2.8127887725830078e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="0" Cut="6.5357315063476562e+01" cType="1" res="1.9078157424926758e+01" rms="3.1198514938354492e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.4706330671906471e-03" rms="2.9198711395263672e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0477781295776367e+00" rms="3.2302230834960938e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="0" Cut="1.3357560729980469e+02" cType="1" res="4.9032112121582031e+01" rms="5.5638324737548828e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="9.4076820373535156e+01" cType="1" res="4.1861690521240234e+01" rms="3.9056049346923828e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.0143496990203857e+00" rms="3.3883186340332031e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.6546277999877930e+00" rms="4.1219169616699219e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="14" Cut="3.9417610168457031e+00" cType="1" res="6.5757339477539062e+01" rms="7.9740913391113281e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.6988515853881836e+00" rms="8.0758766174316406e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.5491333007812500e+00" rms="1.2374700307846069e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="4">
+      <Node pos="s" depth="0" NCoef="0" IVar="3" Cut="8.1231964111328125e+01" cType="1" res="1.2555784225463867e+01" rms="3.9570865631103516e+01" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="0" Cut="4.8951210021972656e+01" cType="1" res="1.6112395524978638e+00" rms="2.6430789947509766e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="3.4115539550781250e+01" cType="1" res="-7.0039811134338379e+00" rms="2.3078865051269531e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.9699997901916504e+00" rms="2.1602416992187500e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.1354879140853882e+00" rms="2.3440855026245117e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="0" Cut="6.4158912658691406e+01" cType="1" res="1.1319061279296875e+01" rms="2.6602796554565430e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.6531348228454590e-01" rms="2.5559288024902344e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.0371841192245483e-01" rms="2.6556100845336914e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="0" Cut="2.3794822692871094e+02" cType="1" res="4.0163131713867188e+01" rms="5.1857475280761719e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="1.4149639892578125e+02" cType="1" res="3.7916774749755859e+01" rms="4.1648017883300781e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.8302218914031982e+00" rms="3.3980411529541016e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.7477488517761230e+00" rms="5.8992431640625000e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="2.0476190567016602e+01" cType="1" res="8.3991020202636719e+01" rms="1.3890824890136719e+02" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.8647943496704102e+01" rms="1.7347782897949219e+02" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.9208082199096680e+01" rms="1.0022953033447266e+02" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="5">
+      <Node pos="s" depth="0" NCoef="0" IVar="0" Cut="7.0575645446777344e+01" cType="1" res="8.0554170608520508e+00" rms="3.2591056823730469e+01" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="0" Cut="4.6699810028076172e+01" cType="1" res="-2.6415476799011230e+00" rms="2.1889331817626953e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="3.4299972534179688e+01" cType="1" res="-8.4886894226074219e+00" rms="2.0070617675781250e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.7329226732254028e+00" rms="1.7745851516723633e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.0724692344665527e+00" rms="2.0964733123779297e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="0" Cut="5.6929889678955078e+01" cType="1" res="4.3719682693481445e+00" rms="2.1919858932495117e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.7338277101516724e-01" rms="2.1594638824462891e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.7298015356063843e-01" rms="2.1648904800415039e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="0" Cut="2.8761267089843750e+02" cType="1" res="2.8146146774291992e+01" rms="3.9225856781005859e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="9.0891418457031250e+01" cType="1" res="2.6504205703735352e+01" rms="3.1277845382690430e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1293088197708130e+00" rms="2.3975130081176758e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.0401215553283691e+00" rms="3.4420837402343750e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="2" Cut="6.6721105575561523e-01" cType="1" res="7.5997055053710938e+01" rms="1.2450302886962891e+02" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.2938400268554688e+01" rms="9.8088516235351562e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.1055004119873047e+01" rms="1.7235473632812500e+02" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="6">
+      <Node pos="s" depth="0" NCoef="0" IVar="0" Cut="8.0599746704101562e+01" cType="1" res="5.3545579910278320e+00" rms="2.6341785430908203e+01" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="0" Cut="5.1446426391601562e+01" cType="1" res="-2.0879857540130615e+00" rms="1.9726837158203125e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="4.0103054046630859e+01" cType="1" res="-8.5949325561523438e+00" rms="1.6663211822509766e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.4087054729461670e+00" rms="1.5540565490722656e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.9137924909591675e-01" rms="1.7284492492675781e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="0" Cut="6.5304901123046875e+01" cType="1" res="6.8472404479980469e+00" rms="2.0106184005737305e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.8291532546281815e-02" rms="1.9748949050903320e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.5252908468246460e-01" rms="1.9652656555175781e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="3" Cut="1.8768835449218750e+02" cType="1" res="2.4636915206909180e+01" rms="3.1114368438720703e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="1.0146479797363281e+02" cType="1" res="2.2897375106811523e+01" rms="2.4693546295166016e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4197808504104614e+00" rms="2.1174554824829102e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.6210091114044189e+00" rms="2.6534679412841797e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="2" Cut="1.3376496732234955e-01" cType="1" res="3.7275207519531250e+01" rms="5.8221897125244141e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1360472679138184e+01" rms="3.3097251892089844e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1422663688659668e+01" rms="7.8684860229492188e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="7">
+      <Node pos="s" depth="0" NCoef="0" IVar="0" Cut="7.0577728271484375e+01" cType="1" res="3.6729738712310791e+00" rms="2.4626684188842773e+01" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="0" Cut="5.1045509338378906e+01" cType="1" res="-5.0831947326660156e+00" rms="1.6053590774536133e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="3.6163894653320312e+01" cType="1" res="-8.9417181015014648e+00" rms="1.4750301361083984e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.3694249391555786e+00" rms="1.3130076408386230e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.6785564422607422e-01" rms="1.5334306716918945e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="8" Cut="6.5197080373764038e-02" cType="1" res="2.2363786697387695e+00" rms="1.5876274108886719e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.9304640889167786e-02" rms="1.5507576942443848e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.0265338420867920e-01" rms="1.6430940628051758e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="0" Cut="1.1398966979980469e+02" cType="1" res="1.9695772171020508e+01" rms="2.9114065170288086e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="9.1253990173339844e+01" cType="1" res="1.5084377288818359e+01" rms="1.8434526443481445e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.8697495460510254e-01" rms="1.7580339431762695e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.9488844871520996e+00" rms="1.8846975326538086e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="0" Cut="2.3800062561035156e+02" cType="1" res="2.8161413192749023e+01" rms="4.0855129241943359e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.4868817329406738e+00" rms="2.4820756912231445e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.5463596343994141e+01" rms="8.9575172424316406e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="8">
+      <Node pos="s" depth="0" NCoef="0" IVar="0" Cut="8.0602783203125000e+01" cType="1" res="2.7017672061920166e+00" rms="1.9221487045288086e+01" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="0" Cut="4.6150924682617188e+01" cType="1" res="-3.2739939689636230e+00" rms="1.5692859649658203e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="3.6071571350097656e+01" cType="1" res="-9.6757411956787109e+00" rms="1.2957375526428223e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.3032311201095581e+00" rms="1.1976808547973633e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.6104223728179932e-01" rms="1.3516012191772461e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="0" Cut="6.5791450500488281e+01" cType="1" res="2.4340248107910156e+00" rms="1.5716948509216309e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.9994357228279114e-01" rms="1.4344687461853027e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.2441778182983398e-01" rms="1.6544551849365234e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="3" Cut="1.3453045654296875e+02" cType="1" res="1.7659488677978516e+01" rms="1.9097782135009766e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="9.8303977966308594e+01" cType="1" res="1.5037200927734375e+01" rms="1.5536808967590332e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0288370847702026e+00" rms="1.5569008827209473e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.1653728485107422e+00" rms="1.4701450347900391e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="6.0971450805664062e-01" cType="1" res="2.3591684341430664e+01" rms="2.4351276397705078e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.2573018074035645e+00" rms="2.1119945526123047e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.7985243797302246e+00" rms="5.8807506561279297e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="9">
+      <Node pos="s" depth="0" NCoef="0" IVar="0" Cut="8.0611755371093750e+01" cType="1" res="2.0929627418518066e+00" rms="1.7031023025512695e+01" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="0" Cut="5.4122791290283203e+01" cType="1" res="-2.9814598560333252e+00" rms="1.3854586601257324e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="3.8859748840332031e+01" cType="1" res="-7.0811882019042969e+00" rms="1.2324293136596680e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.0764853954315186e+00" rms="1.1521041870117188e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.9453520774841309e-01" rms="1.2410459518432617e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="3" Cut="7.0697288513183594e+01" cType="1" res="4.1537299156188965e+00" rms="1.3472539901733398e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2682756781578064e-01" rms="1.3363350868225098e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.0653402805328369e-01" rms="1.2832769393920898e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="3" Cut="1.3444500732421875e+02" cType="1" res="1.5766263961791992e+01" rms="1.7264551162719727e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="1.0083065795898438e+02" cType="1" res="1.3144721984863281e+01" rms="1.2898356437683105e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0207815170288086e+00" rms="1.3055118560791016e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.1174905300140381e+00" rms="1.1849886894226074e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="4" Cut="8.8385047912597656e+01" cType="1" res="2.1618728637695312e+01" rms="2.3291162490844727e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.6017522811889648e+00" rms="2.1177614212036133e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1300953865051270e+01" rms="4.8222511291503906e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="10">
+      <Node pos="s" depth="0" NCoef="0" IVar="0" Cut="8.0611732482910156e+01" cType="1" res="1.5620859861373901e+00" rms="1.5741958618164062e+01" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="0" Cut="4.8838447570800781e+01" cType="1" res="-3.3161294460296631e+00" rms="1.2650033950805664e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="3.0685028076171875e+01" cType="1" res="-7.7075052261352539e+00" rms="1.1424384117126465e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.3243961334228516e+00" rms="1.0186941146850586e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.6153657436370850e-01" rms="1.1455586433410645e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="0" Cut="6.8504600524902344e+01" cType="1" res="1.5630388259887695e+00" rms="1.2148056030273438e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.2217708230018616e-02" rms="1.1795434951782227e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.6891775131225586e-01" rms="1.1767936706542969e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="0" Cut="1.3357560729980469e+02" cType="1" res="1.4137415885925293e+01" rms="1.5956956863403320e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="9.8256202697753906e+01" cType="1" res="1.2068614006042480e+01" rms="1.3776335716247559e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.0168130397796631e-01" rms="1.1629244804382324e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7726404666900635e+00" rms="1.4995789527893066e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="3.4547007083892822e-01" cType="1" res="1.9061407089233398e+01" rms="1.9352308273315430e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.7704644203186035e+00" rms="1.5961315155029297e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.8835344314575195e+00" rms="6.3738674163818359e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="11">
+      <Node pos="s" depth="0" NCoef="0" IVar="0" Cut="7.0578681945800781e+01" cType="1" res="1.2491860389709473e+00" rms="1.4014286041259766e+01" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="0" Cut="4.6705661773681641e+01" cType="1" res="-3.9812629222869873e+00" rms="1.2216298103332520e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="5" Cut="-9.4132514953613281e+01" cType="1" res="-7.4076499938964844e+00" rms="1.0746429443359375e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.1748517751693726e-01" rms="1.0094480514526367e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.4077250957489014e-01" rms="1.1644792556762695e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="5" Cut="-9.4017738342285156e+01" cType="1" res="1.8067415058612823e-01" rms="1.2595780372619629e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.1613748371601105e-01" rms="1.2768196105957031e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.6444309353828430e-01" rms="1.1628113746643066e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="3" Cut="1.1493682098388672e+02" cType="1" res="1.0545081138610840e+01" rms="1.2049262046813965e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="9.1499992370605469e+01" cType="1" res="7.3367490768432617e+00" rms="1.0673344612121582e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.3439331054687500e-01" rms="1.0951001167297363e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1987802982330322e+00" rms="9.5223007202148438e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="6" Cut="9.8912132263183594e+01" cType="1" res="1.6597448348999023e+01" rms="1.2170226097106934e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.4779720306396484e+00" rms="8.6563720703125000e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.8017778396606445e+00" rms="5.9489925384521484e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="12">
+      <Node pos="s" depth="0" NCoef="0" IVar="0" Cut="8.0599746704101562e+01" cType="1" res="9.9696964025497437e-01" rms="1.3684418678283691e+01" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="0" Cut="5.4116786956787109e+01" cType="1" res="-2.7456951141357422e+00" rms="1.1333250045776367e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="5" Cut="-9.4127830505371094e+01" cType="1" res="-5.4634780883789062e+00" rms="1.0710397720336914e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.2056102752685547e-01" rms="1.0144931793212891e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.7075617611408234e-01" rms="1.1349986076354980e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="6" Cut="8.0513591766357422e+00" cType="1" res="1.9925645589828491e+00" rms="1.0819011688232422e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.5574396848678589e-02" rms="1.0562946319580078e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.3572609424591064e-01" rms="1.0804419517517090e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="0" Cut="1.3359078979492188e+02" cType="1" res="1.0717665672302246e+01" rms="1.4462475776672363e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="1.0452102661132812e+02" cType="1" res="8.3233013153076172e+00" rms="1.1803261756896973e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.6640150547027588e-01" rms="1.1801471710205078e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3380154371261597e+00" rms="1.1157231330871582e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="3" Cut="1.8524537658691406e+02" cType="1" res="1.5972933769226074e+01" rms="1.7951719284057617e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.3543679714202881e+00" rms="9.9671335220336914e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.3565387725830078e+00" rms="2.5330513000488281e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="13">
+      <Node pos="s" depth="0" NCoef="0" IVar="0" Cut="6.2973068237304688e+01" cType="1" res="7.4141544103622437e-01" rms="1.2266720771789551e+01" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="0" Cut="4.1256668090820312e+01" cType="1" res="-4.1304860115051270e+00" rms="1.0751501083374023e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="5" Cut="-9.4163871765136719e+01" cType="1" res="-6.7977457046508789e+00" rms="1.0229613304138184e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.2758754491806030e-01" rms="9.8848657608032227e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.8038262724876404e-01" rms="1.0690009117126465e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="6" Cut="1.5230181694030762e+01" cType="1" res="-1.8045343160629272e+00" rms="1.0655019760131836e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.7647513151168823e-01" rms="1.0605907440185547e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.0893042683601379e-01" rms="9.9631719589233398e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="0" Cut="9.9139518737792969e+01" cType="1" res="7.2559757232666016e+00" rms="1.1087471008300781e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="7.1582885742187500e+01" cType="1" res="4.1585760116577148e+00" rms="1.0686800956726074e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2137813121080399e-01" rms="1.0820195198059082e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.9138703346252441e-01" rms="1.0411593437194824e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="0" Cut="1.6805244445800781e+02" cType="1" res="1.1605443954467773e+01" rms="1.0138689994812012e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2908743619918823e+00" rms="9.7548103332519531e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.0441837310791016e+00" rms="9.5569791793823242e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="14">
+      <Node pos="s" depth="0" NCoef="0" IVar="0" Cut="7.2803024291992188e+01" cType="1" res="5.8501237630844116e-01" rms="1.1607276916503906e+01" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="0" Cut="5.2308589935302734e+01" cType="1" res="-3.0844607353210449e+00" rms="1.0555452346801758e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="3.1502843856811523e+01" cType="1" res="-4.9315276145935059e+00" rms="9.9805688858032227e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.7986707687377930e-01" rms="9.5457258224487305e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.1389802098274231e-01" rms="9.9218997955322266e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="7" Cut="-9.4268829345703125e+01" cType="1" res="5.1648312807083130e-01" rms="1.0715202331542969e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.2580899894237518e-01" rms="1.0786321640014648e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.4890687465667725e-01" rms="1.0044193267822266e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="3" Cut="1.6513047790527344e+02" cType="1" res="7.8601417541503906e+00" rms="1.0065917968750000e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="9.9438705444335938e+01" cType="1" res="6.7238044738769531e+00" rms="1.0228990554809570e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.9916166067123413e-01" rms="1.0164406776428223e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2206447124481201e+00" rms="9.7551021575927734e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="0" Cut="2.0338580322265625e+02" cType="1" res="1.5118587493896484e+01" rms="4.3874425888061523e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.3380880355834961e+00" rms="5.8130221366882324e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.8620104789733887e+00" rms="1.5078692436218262e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="15">
+      <Node pos="s" depth="0" NCoef="0" IVar="0" Cut="8.0602783203125000e+01" cType="1" res="6.3240176439285278e-01" rms="1.1281466484069824e+01" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="0" Cut="5.1471576690673828e+01" cType="1" res="-2.1469981670379639e+00" rms="1.0333120346069336e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="6" Cut="-9.2756164550781250e+01" cType="1" res="-4.2807893753051758e+00" rms="9.8846149444580078e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.7688367366790771e-01" rms="9.4375610351562500e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.1367480456829071e-01" rms="1.0464607238769531e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="0" Cut="7.2270347595214844e+01" cType="1" res="8.7593132257461548e-01" rms="1.0199570655822754e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.4920145347714424e-03" rms="1.0250365257263184e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.5967251658439636e-01" rms="9.5292921066284180e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="3" Cut="1.3438346862792969e+02" cType="1" res="7.9139127731323242e+00" rms="1.0378540039062500e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="1.0337217712402344e+02" cType="1" res="5.9520707130432129e+00" rms="9.9659919738769531e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.3325170278549194e-01" rms="1.0208666801452637e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.2503786087036133e-01" rms="9.2960882186889648e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="0" Cut="1.8146467590332031e+02" cType="1" res="1.2264281272888184e+01" rms="9.9431028366088867e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7319353818893433e+00" rms="1.2309823989868164e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.4131712913513184e+00" rms="3.3824412822723389e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="16">
+      <Node pos="s" depth="0" NCoef="0" IVar="3" Cut="7.1304512023925781e+01" cType="1" res="4.5718136429786682e-01" rms="1.0736220359802246e+01" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="0" Cut="4.2374290466308594e+01" cType="1" res="-2.6920800209045410e+00" rms="9.7737169265747070e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="2.9142997741699219e+01" cType="1" res="-5.1773309707641602e+00" rms="9.2871665954589844e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.9222290515899658e-01" rms="8.5714597702026367e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.5307609438896179e-01" rms="9.2988948822021484e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="6" Cut="7.7100172042846680e+00" cType="1" res="-7.9660457372665405e-01" rms="9.7105722427368164e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.9496491551399231e-01" rms="9.4245748519897461e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.8203228116035461e-01" rms="9.9921731948852539e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="0" Cut="1.5657691955566406e+02" cType="1" res="6.2429938316345215e+00" rms="9.9918813705444336e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="9.0291351318359375e+01" cType="1" res="4.8027844429016113e+00" rms="1.0057307243347168e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.3281046152114868e-01" rms="9.9410781860351562e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.1848406791687012e-01" rms="9.9488821029663086e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="3" Cut="1.9711366271972656e+02" cType="1" res="1.3590218544006348e+01" rms="5.3462729454040527e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.5215001106262207e+00" rms="6.7794322967529297e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.9715957641601562e+00" rms="3.3241262435913086e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="17">
+      <Node pos="s" depth="0" NCoef="0" IVar="0" Cut="6.2985076904296875e+01" cType="1" res="6.0263890027999878e-01" rms="1.0551656723022461e+01" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="0" Cut="3.9475502014160156e+01" cType="1" res="-2.7171254158020020e+00" rms="9.6375379562377930e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="15" Cut="7.2150307893753052e-01" cType="1" res="-4.9424319267272949e+00" rms="9.1372013092041016e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.0673201084136963e-01" rms="8.9273242950439453e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.7876861989498138e-01" rms="9.4932775497436523e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="6" Cut="1.3483297348022461e+01" cType="1" res="-1.1789515018463135e+00" rms="9.6740036010742188e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.8967366218566895e-01" rms="9.6030607223510742e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.5044643878936768e-01" rms="9.5840511322021484e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="0" Cut="1.7149591064453125e+02" cType="1" res="4.8981571197509766e+00" rms="1.0124505043029785e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="1.0431215667724609e+02" cType="1" res="4.0263400077819824e+00" rms="1.0098963737487793e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.2016968727111816e-01" rms="9.8147964477539062e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.1904497146606445e-01" rms="1.0230399131774902e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="3" Cut="2.6678036499023438e+02" cType="1" res="1.3222079277038574e+01" rms="5.5581226348876953e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.1024115085601807e+00" rms="6.4391069412231445e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0484861373901367e+01" rms="7.0483952760696411e-01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="18">
+      <Node pos="s" depth="0" NCoef="0" IVar="0" Cut="7.2800933837890625e+01" cType="1" res="6.2567275762557983e-01" rms="1.0253628730773926e+01" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="0" Cut="4.3208290100097656e+01" cType="1" res="-1.7485598325729370e+00" rms="9.5872058868408203e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="2.8467847824096680e+01" cType="1" res="-3.8749706745147705e+00" rms="9.0340776443481445e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.3540282249450684e-01" rms="9.0743741989135742e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.3601874113082886e-01" rms="8.9153633117675781e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="6" Cut="1.0487476348876953e+01" cType="1" res="-3.2855857163667679e-02" rms="9.6764221191406250e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.0023453086614609e-01" rms="9.4985132217407227e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.3355703353881836e-01" rms="9.7843484878540039e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="3" Cut="1.6502214050292969e+02" cType="1" res="5.2750120162963867e+00" rms="9.9183998107910156e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="2" Cut="-2.1683297157287598e+00" cType="1" res="4.0877628326416016e+00" rms="9.9321451187133789e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.5634273290634155e-01" rms="9.8466339111328125e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.2250450849533081e-01" rms="9.7903451919555664e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="14" Cut="3.6877574920654297e+00" cType="1" res="1.2047835350036621e+01" rms="6.5502653121948242e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.4389033317565918e+00" rms="5.6421327590942383e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.0849615335464478e-01" rms="1.2107154846191406e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="19">
+      <Node pos="s" depth="0" NCoef="0" IVar="0" Cut="7.2800933837890625e+01" cType="1" res="4.1910833120346069e-01" rms="1.0201928138732910e+01" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="0" Cut="5.4587677001953125e+01" cType="1" res="-1.8287156820297241e+00" rms="9.5898561477661133e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="2.9226913452148438e+01" cType="1" res="-2.9284391403198242e+00" rms="9.3305692672729492e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.2080016136169434e-01" rms="8.7135534286499023e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.7549067139625549e-01" rms="9.3117189407348633e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="8" Cut="2.2818978130817413e-01" cType="1" res="6.0901343822479248e-01" rms="9.7065238952636719e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.5902005881071091e-03" rms="9.7060708999633789e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.6801890134811401e-01" rms="8.1575050354003906e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="0" Cut="1.6385667419433594e+02" cType="1" res="4.8479571342468262e+00" rms="9.9185352325439453e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="2" Cut="-2.1679408550262451e+00" cType="1" res="3.6890351772308350e+00" rms="9.9181337356567383e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.6718302965164185e-01" rms="9.5309572219848633e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.8275545239448547e-01" rms="9.7584829330444336e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="16" Cut="4.0000000000000000e+00" cType="1" res="1.1429267883300781e+01" rms="6.7820901870727539e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.4819014072418213e+00" rms="5.6223254203796387e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.2075846195220947e+00" rms="8.9744510650634766e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="20">
+      <Node pos="s" depth="0" NCoef="0" IVar="3" Cut="8.1280044555664062e+01" cType="1" res="1.5831939876079559e-01" rms="9.9677143096923828e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="0" Cut="4.3615512847900391e+01" cType="1" res="-1.4975228309631348e+00" rms="9.3617296218872070e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="6" Cut="-9.3061599731445312e+01" cType="1" res="-3.4180073738098145e+00" rms="8.9620046615600586e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.5349586009979248e-01" rms="8.5994844436645508e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.2325169146060944e-01" rms="9.6193590164184570e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="5" Cut="-9.4075248718261719e+01" cType="1" res="-7.0287391543388367e-02" rms="9.3971948623657227e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.3537073135375977e-01" rms="9.1785554885864258e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.2595381736755371e-01" rms="9.5580387115478516e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="0" Cut="1.8541412353515625e+02" cType="1" res="4.3182816505432129e+00" rms="1.0226884841918945e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="1.4984559631347656e+02" cType="1" res="3.5378623008728027e+00" rms="1.0227736473083496e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.2351681590080261e-01" rms="1.0225736618041992e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.5459582805633545e+00" rms="8.0581693649291992e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="14" Cut="2.5031917095184326e+00" cType="1" res="1.0623685836791992e+01" rms="7.7310700416564941e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.4375982284545898e+00" rms="6.2552065849304199e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0247712135314941e+00" rms="1.2143877983093262e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="21">
+      <Node pos="s" depth="0" NCoef="0" IVar="0" Cut="8.0599746704101562e+01" cType="1" res="3.4671312570571899e-01" rms="9.7578601837158203e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="0" Cut="5.4116786956787109e+01" cType="1" res="-1.0868210792541504e+00" rms="9.2317209243774414e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="15" Cut="9.8660039901733398e-01" cType="1" res="-2.3896000385284424e+00" rms="8.9191284179687500e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.3432215452194214e-01" rms="8.7517213821411133e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2913404405117035e-01" rms="9.1952753067016602e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="6" Cut="9.3695383071899414e+00" cType="1" res="1.2133305072784424e+00" rms="9.3249607086181641e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.6858664602041245e-02" rms="9.2351360321044922e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.6164584159851074e-01" rms="9.2038621902465820e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="3" Cut="1.8786695861816406e+02" cType="1" res="4.1771287918090820e+00" rms="1.0087080955505371e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="1.5232511901855469e+02" cType="1" res="3.3788704872131348e+00" rms="1.0071413040161133e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.1796595454216003e-01" rms="1.0060931205749512e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4956572055816650e+00" rms="8.3863563537597656e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="0" Cut="2.3442192077636719e+02" cType="1" res="1.0405546188354492e+01" rms="7.7748670578002930e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3904763460159302e+00" rms="9.4261283874511719e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.4319257736206055e+00" rms="4.9522056579589844e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="22">
+      <Node pos="s" depth="0" NCoef="0" IVar="0" Cut="7.2803024291992188e+01" cType="1" res="3.1835889816284180e-01" rms="9.6307306289672852e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="0" Cut="4.3206825256347656e+01" cType="1" res="-1.2920763492584229e+00" rms="9.1059646606445312e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="6" Cut="4.8623642921447754e+00" cType="1" res="-2.9439187049865723e+00" rms="8.7066392898559570e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.0387147665023804e-01" rms="8.4233236312866211e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.1767546683549881e-03" rms="9.2890853881835938e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="8" Cut="2.2916574776172638e-01" cType="1" res="7.0605218410491943e-02" rms="9.2020988464355469e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.3894112110137939e-02" rms="9.1780223846435547e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.4482978582382202e-01" rms="8.4590253829956055e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="3" Cut="1.6502214050292969e+02" cType="1" res="3.4358906745910645e+00" rms="9.8511524200439453e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="7" Cut="-9.4269073486328125e+01" cType="1" res="2.5600843429565430e+00" rms="9.7679395675659180e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4713731408119202e-01" rms="9.7291316986083984e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.9301095008850098e-01" rms="9.4294443130493164e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="0" Cut="2.0483174133300781e+02" cType="1" res="8.7046871185302734e+00" rms="8.6308670043945312e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0901439189910889e+00" rms="9.5219402313232422e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.8404593467712402e+00" rms="6.5298480987548828e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="23">
+      <Node pos="s" depth="0" NCoef="0" IVar="0" Cut="8.0599746704101562e+01" cType="1" res="2.3222696781158447e-01" rms="9.5457324981689453e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="0" Cut="3.8227207183837891e+01" cType="1" res="-9.9204921722412109e-01" rms="9.0408287048339844e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="2.8148637771606445e+01" cType="1" res="-2.9813940525054932e+00" rms="8.6349296569824219e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.3767641782760620e-01" rms="8.4433650970458984e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.4621374905109406e-01" rms="8.5859203338623047e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="15" Cut="9.9836087226867676e-01" cType="1" res="-1.8047022819519043e-01" rms="9.0769147872924805e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.0390108078718185e-01" rms="9.0302057266235352e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.0812088251113892e-01" rms="8.9676980972290039e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="0" Cut="2.3948077392578125e+02" cType="1" res="3.5506482124328613e+00" rms="1.0073879241943359e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="1.4864070129394531e+02" cType="1" res="3.0506649017333984e+00" rms="1.0062219619750977e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.8265666961669922e-01" rms="9.9682245254516602e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2393877506256104e+00" rms="9.8434009552001953e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="3" Cut="2.8634555053710938e+02" cType="1" res="1.1550381660461426e+01" rms="6.1027922630310059e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.9059637784957886e+00" rms="8.8232145309448242e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.7406568527221680e+00" rms="2.8413027524948120e-01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="24">
+      <Node pos="s" depth="0" NCoef="0" IVar="4" Cut="1.4839471817016602e+01" cType="1" res="4.0789249539375305e-01" rms="9.6286916732788086e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="11" Cut="3.1553116440773010e-01" cType="1" res="-1.2456775903701782e+00" rms="9.0334234237670898e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="15" Cut="7.7073335647583008e-01" cType="1" res="-2.4405722618103027e+00" rms="8.7893714904785156e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.8314762711524963e-01" rms="8.5105829238891602e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.2247369885444641e-02" rms="9.2640600204467773e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="0" Cut="5.8736957550048828e+01" cType="1" res="1.2067987769842148e-01" rms="9.1146602630615234e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.2485029697418213e-02" rms="8.7782640457153320e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7676059901714325e-01" rms="9.5626630783081055e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="0" Cut="2.1490438842773438e+02" cType="1" res="2.9398710727691650e+00" rms="9.9561147689819336e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="5" Cut="-9.3956947326660156e+01" cType="1" res="2.4960596561431885e+00" rms="9.9133424758911133e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4423267543315887e-01" rms="9.6753807067871094e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.9023892879486084e-01" rms="1.0059450149536133e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="3" Cut="2.7496881103515625e+02" cType="1" res="1.0893382072448730e+01" rms="6.8968195915222168e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.8645474910736084e+00" rms="8.8516492843627930e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.3678970336914062e+00" rms="7.0220029354095459e-01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="25">
+      <Node pos="s" depth="0" NCoef="0" IVar="3" Cut="7.1276985168457031e+01" cType="1" res="1.4265044033527374e-01" rms="9.4236593246459961e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="0" Cut="5.3234577178955078e+01" cType="1" res="-1.1081899404525757e+00" rms="8.8674240112304688e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="6" Cut="7.8957071304321289e+00" cType="1" res="-1.8041471242904663e+00" rms="8.6756896972656250e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.6307159662246704e-01" rms="8.5030832290649414e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.0294371098279953e-02" rms="9.2062702178955078e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="2" Cut="1.9376217126846313e+00" cType="1" res="5.1488655805587769e-01" rms="9.0945968627929688e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.3361506462097168e-02" rms="8.9950485229492188e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.2613626718521118e-01" rms="9.3222160339355469e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="0" Cut="2.4353617858886719e+02" cType="1" res="2.4044206142425537e+00" rms="9.9628067016601562e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="2" Cut="-1.9395706653594971e+00" cType="1" res="2.0409357547760010e+00" rms="9.9257936477661133e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.2479776144027710e-01" rms="9.7326402664184570e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.0647259950637817e-01" rms="9.8324127197265625e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="0" Cut="2.7885760498046875e+02" cType="1" res="1.1753459930419922e+01" rms="5.2334256172180176e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.8083620071411133e+00" rms="8.4563617706298828e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.3235354423522949e+00" rms="1.8893957138061523e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="26">
+      <Node pos="s" depth="0" NCoef="0" IVar="4" Cut="2.9036830902099609e+01" cType="1" res="1.5620349347591400e-01" rms="9.3430385589599609e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="0" Cut="5.7362190246582031e+01" cType="1" res="-3.4710124135017395e-01" rms="9.1527738571166992e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="15" Cut="9.1880571842193604e-01" cType="1" res="-1.2727013826370239e+00" rms="8.6789636611938477e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.0672953128814697e-01" rms="8.5722751617431641e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.5254832804203033e-01" rms="8.7916870117187500e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="2" Cut="-1.9395706653594971e+00" cType="1" res="8.8205850124359131e-01" rms="9.6096019744873047e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.4700171947479248e-01" rms="9.2160863876342773e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2440511584281921e-01" rms="9.5566110610961914e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="3" Cut="2.6360723876953125e+02" cType="1" res="4.3317351341247559e+00" rms="9.8463754653930664e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="2" Cut="1.9141263961791992e+00" cType="1" res="3.7044506072998047e+00" rms="9.8561258316040039e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.4954912662506104e-01" rms="9.7420797348022461e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.5584752559661865e-01" rms="9.5978784561157227e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="3" Cut="3.0916683959960938e+02" cType="1" res="1.1556078910827637e+01" rms="6.1656861305236816e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.1515345573425293e+00" rms="9.5710601806640625e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.7207002639770508e+00" rms="1.0493881702423096e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="27">
+      <Node pos="s" depth="0" NCoef="0" IVar="3" Cut="1.2171098327636719e+02" cType="1" res="2.7385321259498596e-01" rms="9.2742223739624023e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="7" Cut="-9.4267890930175781e+01" cType="1" res="-2.7304062247276306e-01" rms="9.0273666381835938e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="2.8011381626129150e-01" cType="1" res="-9.5312899351119995e-01" rms="8.7750577926635742e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.5705447793006897e-01" rms="8.6109180450439453e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.0170374065637589e-02" rms="8.8283185958862305e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="0" Cut="6.1391555786132812e+01" cType="1" res="1.3069676160812378e+00" rms="9.3998765945434570e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.6049498021602631e-02" rms="9.1293478012084961e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.8937342166900635e-01" rms="9.5736789703369141e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="3" Cut="2.5251701354980469e+02" cType="1" res="4.5907125473022461e+00" rms="1.0033762931823730e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="6" Cut="4.6034154891967773e+00" cType="1" res="3.7798392772674561e+00" rms="1.0151828765869141e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.2130287885665894e-01" rms="1.0364047050476074e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2793415784835815e+00" rms="9.1017780303955078e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="0" Cut="3.2408886718750000e+02" cType="1" res="1.0463753700256348e+01" rms="6.6453099250793457e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7076401710510254e+00" rms="8.2688055038452148e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.0631942749023438e+00" rms="2.5826713442802429e-01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="28">
+      <Node pos="s" depth="0" NCoef="0" IVar="4" Cut="1.6549177169799805e+01" cType="1" res="1.4244695007801056e-01" rms="9.1930322647094727e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="11" Cut="3.1132748723030090e-01" cType="1" res="-8.0581188201904297e-01" rms="8.8757581710815430e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="6.3260837554931641e+01" cType="1" res="-1.8429634571075439e+00" rms="8.6559114456176758e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.8678688406944275e-01" rms="8.4201250076293945e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.1275816261768341e-02" rms="9.3021726608276367e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="6.9289714097976685e-01" cType="1" res="3.7735435366630554e-01" rms="8.9749078750610352e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1865018866956234e-02" rms="8.9481258392333984e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7020752429962158e+00" rms="4.2869653701782227e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="0" Cut="2.1936334228515625e+02" cType="1" res="2.1806449890136719e+00" rms="9.5261192321777344e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="6" Cut="-8.5751144409179688e+01" cType="1" res="1.8033407926559448e+00" rms="9.4657888412475586e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.5645347833633423e-02" rms="9.4677877426147461e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.6355307102203369e-01" rms="9.2594194412231445e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="0" Cut="3.1182800292968750e+02" cType="1" res="8.6032457351684570e+00" rms="8.1595268249511719e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.5001099109649658e+00" rms="9.1112565994262695e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.4741935729980469e+00" rms="4.4724506139755249e-01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="29">
+      <Node pos="s" depth="0" NCoef="0" IVar="4" Cut="1.4674618721008301e+01" cType="1" res="1.7134597897529602e-01" rms="9.1373395919799805e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="11" Cut="3.2679945230484009e-01" cType="1" res="-9.0435290336608887e-01" rms="8.7235145568847656e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="4" Cut="7.5558037757873535e+00" cType="1" res="-1.7960308790206909e+00" rms="8.5566730499267578e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.0146309137344360e-01" rms="7.9949302673339844e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.4121019840240479e-01" rms="8.7005147933959961e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="4" Cut="6.5221819877624512e+00" cType="1" res="1.9669795036315918e-01" rms="8.8014554977416992e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.5816031396389008e-01" rms="8.5127096176147461e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0663859546184540e-01" rms="8.8723468780517578e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="0" Cut="3.1627456665039062e+02" cType="1" res="1.7341015338897705e+00" rms="9.4923973083496094e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="1.4830139160156250e+02" cType="1" res="1.5556212663650513e+00" rms="9.4656085968017578e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3555160164833069e-01" rms="9.3184013366699219e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.4618661403656006e-01" rms="9.9993581771850586e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="0" Cut="3.5517022705078125e+02" cType="1" res="1.2160325050354004e+01" rms="3.0340821743011475e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.6957471370697021e+00" rms="5.1996412277221680e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.6169815063476562e+00" rms="1.8146735429763794e-01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="30">
+      <Node pos="s" depth="0" NCoef="0" IVar="0" Cut="8.9896255493164062e+01" cType="1" res="1.5585601329803467e-01" rms="9.0645694732666016e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="0" Cut="2.8091220855712891e+01" cType="1" res="-5.2386295795440674e-01" rms="8.7279005050659180e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="12" Cut="1.1428571701049805e+01" cType="1" res="-3.7741870880126953e+00" rms="8.6647834777832031e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.3140081167221069e-01" rms="9.3901510238647461e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.1799281835556030e-01" rms="7.6517896652221680e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="2" Cut="2.1657142639160156e+00" cType="1" res="-3.0180177092552185e-01" rms="8.6879320144653320e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.9927538484334946e-02" rms="8.6650800704956055e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.3231756687164307e-01" rms="8.1260490417480469e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="0" Cut="3.2479028320312500e+02" cType="1" res="2.6347949504852295e+00" rms="9.8072690963745117e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="2" Cut="1.9428682327270508e+00" cType="1" res="2.4408133029937744e+00" rms="9.7947835922241211e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.3722248077392578e-01" rms="9.7154750823974609e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.6122994422912598e-01" rms="9.9346570968627930e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="2" Cut="2.7515190839767456e-01" cType="1" res="1.2460190773010254e+01" rms="3.1835405826568604e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.4093985557556152e+00" rms="4.3539800643920898e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.9265060424804688e+00" rms="4.5238813757896423e-01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="31">
+      <Node pos="s" depth="0" NCoef="0" IVar="3" Cut="1.0401568603515625e+02" cType="1" res="1.5746018290519714e-01" rms="9.0796213150024414e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="5" Cut="-9.3975250244140625e+01" cType="1" res="-3.5843250155448914e-01" rms="8.7668867111206055e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="3.7348508834838867e-01" cType="1" res="-9.0691930055618286e-01" rms="8.5565671920776367e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.9862519204616547e-01" rms="8.4321918487548828e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.6110873818397522e-02" rms="8.6731100082397461e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="7" Cut="7.4982471764087677e-02" cType="1" res="9.3640482425689697e-01" rms="9.1144275665283203e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.7477356791496277e-01" rms="9.0783596038818359e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.2156526595354080e-02" rms="9.0044193267822266e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="0" Cut="2.0794085693359375e+02" cType="1" res="2.8164098262786865e+00" rms="1.0137248992919922e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="14" Cut="3.3644502162933350e+00" cType="1" res="2.0621037483215332e+00" rms="1.0129409790039062e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.7457323074340820e-01" rms="1.0029148101806641e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.1604416370391846e-01" rms="1.0598795890808105e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="0" Cut="3.5901144409179688e+02" cType="1" res="7.2375669479370117e+00" rms="8.9896326065063477e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4128884077072144e+00" rms="9.4813499450683594e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.7836079597473145e+00" rms="6.3496100902557373e-01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="32">
+      <Node pos="s" depth="0" NCoef="0" IVar="0" Cut="1.9180780029296875e+02" cType="1" res="2.5280341506004333e-01" rms="9.0632953643798828e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="3" Cut="8.9618202209472656e+01" cType="1" res="8.1307969987392426e-02" rms="8.9772071838378906e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="2.8059162139892578e+01" cType="1" res="-3.0406206846237183e-01" rms="8.7186203002929688e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.9892914891242981e-01" rms="8.1117963790893555e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.4711253121495247e-02" rms="8.7210216522216797e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="2" Cut="2.1710932254791260e+00" cType="1" res="1.6412137746810913e+00" rms="9.8019495010375977e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.6140728592872620e-01" rms="9.7371959686279297e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.8040602207183838e-01" rms="1.0144172668457031e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="3" Cut="3.3737225341796875e+02" cType="1" res="5.6902494430541992e+00" rms="1.0044252395629883e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="12" Cut="1.7000000000000000e+01" cType="1" res="4.3263249397277832e+00" rms="1.0409379005432129e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.9351253807544708e-02" rms="1.0878046989440918e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3376163244247437e+00" rms="9.5727624893188477e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="2" Cut="1.7807234078645706e-02" cType="1" res="1.2232036590576172e+01" rms="3.6537709236145020e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.7241973876953125e+00" rms="5.7191710472106934e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.4621849060058594e+00" rms="9.2265516519546509e-02" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="33">
+      <Node pos="s" depth="0" NCoef="0" IVar="4" Cut="2.8798269271850586e+01" cType="1" res="3.1423008441925049e-01" rms="9.0626735687255859e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="4" Cut="1.1365303993225098e+01" cType="1" res="-7.8902058303356171e-02" rms="8.9169645309448242e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="4.3365347385406494e-01" cType="1" res="-9.2751801013946533e-01" rms="8.5726051330566406e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.0396241545677185e-01" rms="8.3845129013061523e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.7148180007934570e-02" rms="8.8085660934448242e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="14" Cut="3.2346565723419189e+00" cType="1" res="8.5742056369781494e-01" rms="9.1916332244873047e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3648691773414612e-01" rms="9.1926679611206055e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.0350762009620667e-01" rms="8.1956682205200195e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="0" Cut="3.1655929565429688e+02" cType="1" res="3.5188207626342773e+00" rms="9.5894689559936523e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="6" Cut="3.1069795608520508e+01" cType="1" res="3.1056084632873535e+00" rms="9.5834455490112305e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.3185359835624695e-01" rms="9.6051473617553711e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3557320833206177e+00" rms="8.6080656051635742e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="0" Cut="4.0157791137695312e+02" cType="1" res="1.1195869445800781e+01" rms="5.6563558578491211e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.5803534984588623e+00" rms="7.5001983642578125e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2188849449157715e+01" rms="9.0596117079257965e-02" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="34">
+      <Node pos="s" depth="0" NCoef="0" IVar="3" Cut="1.2171098327636719e+02" cType="1" res="2.0602163672447205e-01" rms="9.0817842483520508e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="2" Cut="1.9391883611679077e+00" cType="1" res="-1.4704081416130066e-01" rms="8.8796253204345703e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="2" Cut="-1.9835602045059204e+00" cType="1" res="3.0830062925815582e-02" rms="8.8427925109863281e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.8187631368637085e-01" rms="9.0713100433349609e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.7790465652942657e-03" rms="8.7967529296875000e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="1.2609052658081055e-01" cType="1" res="-3.2954640388488770e+00" rms="8.9403266906738281e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.3073329925537109e-01" rms="8.9575424194335938e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.7135338783264160e-01" rms="8.3199548721313477e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="0" Cut="2.4991893005371094e+02" cType="1" res="3.0979211330413818e+00" rms="1.0140830039978027e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="2" Cut="-1.9328762292861938e+00" cType="1" res="2.4524738788604736e+00" rms="1.0160776138305664e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.2910937070846558e-01" rms="8.3164186477661133e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.3340554237365723e-01" rms="1.0090874671936035e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="0" Cut="3.6470431518554688e+02" cType="1" res="9.1519765853881836e+00" rms="7.6471619606018066e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7922546863555908e+00" rms="8.6805019378662109e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7635152816772461e+01" rms="9.6113093197345734e-02" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="35">
+      <Node pos="s" depth="0" NCoef="0" IVar="3" Cut="1.2177420806884766e+02" cType="1" res="2.2822096943855286e-01" rms="9.0625877380371094e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="8" Cut="3.3574666827917099e-02" cType="1" res="-1.0066013038158417e-01" rms="8.8394050598144531e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="2.9576551437377930e+01" cType="1" res="-4.6680107712745667e-01" rms="8.7946691513061523e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.3574208617210388e-01" rms="8.1009464263916016e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.3663596510887146e-02" rms="8.8247480392456055e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="13" Cut="3.7997989654541016e+01" cType="1" res="1.6926405429840088e+00" rms="8.8389139175415039e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7095997929573059e-01" rms="8.8589277267456055e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.6048671007156372e-01" rms="6.7341523170471191e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="0" Cut="3.3626660156250000e+02" cType="1" res="3.0072662830352783e+00" rms="1.0356383323669434e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="7.9348582029342651e-01" cType="1" res="2.6154780387878418e+00" rms="1.0385509490966797e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.1214475035667419e-01" rms="1.0534449577331543e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.5904839038848877e-01" rms="8.9334058761596680e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="2.5190475463867188e+01" cType="1" res="1.1234817504882812e+01" rms="4.8633303642272949e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.6019039154052734e+00" rms="6.1430320739746094e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.2485532760620117e+00" rms="9.3358826637268066e-01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="36">
+      <Node pos="s" depth="0" NCoef="0" IVar="4" Cut="1.2144856452941895e+01" cType="1" res="9.2282379046082497e-03" rms="8.9255056381225586e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="11" Cut="3.3095067739486694e-01" cType="1" res="-8.1549268960952759e-01" rms="8.4023666381835938e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="14" Cut="2.2165396213531494e+00" cType="1" res="-1.6463049650192261e+00" rms="8.1747159957885742e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.6893118619918823e-01" rms="8.2193050384521484e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.1143253445625305e-01" rms="7.5997095108032227e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="6.8789988756179810e-01" cType="1" res="1.4663015305995941e-01" rms="8.5583286285400391e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.4013490229845047e-03" rms="8.5085821151733398e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.0795261859893799e+00" rms="4.4897648692131042e-01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="4" Cut="3.4455730438232422e+01" cType="1" res="8.3834463357925415e-01" rms="9.3491497039794922e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="2.2221791744232178e-01" cType="1" res="5.0845271348953247e-01" rms="9.1999406814575195e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.8434670567512512e-02" rms="9.0407323837280273e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.5795613825321198e-01" rms="9.2769804000854492e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="2" Cut="1.6958945989608765e+00" cType="1" res="2.6293063163757324e+00" rms="9.9314565658569336e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.1933366060256958e-01" rms="9.8200740814208984e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.2430071830749512e-01" rms="9.0025320053100586e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="37">
+      <Node pos="s" depth="0" NCoef="0" IVar="3" Cut="2.1809400939941406e+02" cType="1" res="1.3417164981365204e-01" rms="8.9000310897827148e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="2" Cut="2.1710932254791260e+00" cType="1" res="8.9926170185208321e-03" rms="8.8447370529174805e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="15" Cut="1.1372731924057007e+00" cType="1" res="1.1823756247758865e-01" rms="8.8240909576416016e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.1524333655834198e-02" rms="8.7224912643432617e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.0763602852821350e-01" rms="9.1014060974121094e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="2.0375417709350586e+01" cType="1" res="-4.3375525474548340e+00" rms="8.5659818649291992e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.9376661181449890e-01" rms="9.0251665115356445e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.4425648450851440e-01" rms="6.9534096717834473e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="0" Cut="2.9539944458007812e+02" cType="1" res="5.8867430686950684e+00" rms="9.5125446319580078e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="2.3082688903808594e+02" cType="1" res="3.7225825786590576e+00" rms="1.0063362121582031e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7259508371353149e+00" rms="6.6282558441162109e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.9955166578292847e-01" rms="1.0653874397277832e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="4" Cut="6.0102680206298828e+01" cType="1" res="8.5053777694702148e+00" rms="8.0571069717407227e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.4651730060577393e+00" rms="4.5698461532592773e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.1671756505966187e-01" rms="1.0069176673889160e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="38">
+      <Node pos="s" depth="0" NCoef="0" IVar="0" Cut="2.1620039367675781e+02" cType="1" res="1.4656166732311249e-01" rms="8.8859710693359375e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="0" Cut="6.1388282775878906e+01" cType="1" res="2.7912823483347893e-02" rms="8.8374481201171875e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="15" Cut="1.2615997791290283e+00" cType="1" res="-4.8578718304634094e-01" rms="8.3472080230712891e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.1382276564836502e-01" rms="8.2506561279296875e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.6010316610336304e-01" rms="8.5960741043090820e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="14" Cut="1.1744780540466309e+00" cType="1" res="7.0342952013015747e-01" rms="9.4008264541625977e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.3404452204704285e-01" rms="9.5101261138916016e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.0361731350421906e-02" rms="9.1487798690795898e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="0" Cut="4.4850405883789062e+02" cType="1" res="5.7773442268371582e+00" rms="9.3487901687622070e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="4" Cut="4.6546131134033203e+01" cType="1" res="5.0245418548583984e+00" rms="9.5543775558471680e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1882115602493286e+00" rms="8.9386215209960938e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.6381895542144775e-01" rms="9.9703016281127930e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.8641712188720703e+01" rms="1.3707233965396881e-01" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="39">
+      <Node pos="s" depth="0" NCoef="0" IVar="2" Cut="-1.9428572654724121e+00" cType="1" res="1.3773153722286224e-01" rms="8.8478813171386719e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="9" Cut="7.3716682195663452e-01" cType="1" res="-2.6713414192199707e+00" rms="8.7614498138427734e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="8" Cut="5.3152542561292648e-02" cType="1" res="-3.3325445652008057e+00" rms="8.6079349517822266e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.9509676694869995e-01" rms="8.4343757629394531e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4887630939483643e-01" rms="8.2416372299194336e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="1.5325169265270233e-01" cType="1" res="1.0217208862304688e+00" rms="8.6934223175048828e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.9701309204101562e-01" rms="8.0103187561035156e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.4440152645111084e-01" rms="7.6943812370300293e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="14" Cut="2.3489561080932617e+00" cType="1" res="2.9166895151138306e-01" rms="8.8267936706542969e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="4" Cut="2.8798269271850586e+01" cType="1" res="5.3458893299102783e-01" rms="8.8000621795654297e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.5474335998296738e-02" rms="8.6419143676757812e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.5214095711708069e-01" rms="9.8058376312255859e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="3" Cut="2.2137013244628906e+02" cType="1" res="-1.5008988380432129e+00" rms="8.8170642852783203e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.4823039770126343e-01" rms="8.7273397445678711e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.5366820096969604e+00" rms="9.2153139114379883e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="40">
+      <Node pos="s" depth="0" NCoef="0" IVar="0" Cut="8.0599746704101562e+01" cType="1" res="1.1463177204132080e-01" rms="8.8896436691284180e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="3" Cut="3.3548770904541016e+01" cType="1" res="-2.6046320796012878e-01" rms="8.4536685943603516e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="15" Cut="5.4460626840591431e-01" cType="1" res="-1.5724154710769653e+00" rms="7.8605661392211914e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.5070267915725708e-01" rms="7.7457132339477539e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.1007214486598969e-02" rms="8.0036153793334961e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="1.4000000000000000e+01" cType="1" res="9.0471766889095306e-03" rms="8.5455255508422852e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.6726362109184265e-02" rms="8.4978094100952148e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.0649091005325317e-01" rms="8.5355873107910156e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="14" Cut="2.8037085533142090e+00" cType="1" res="1.1110149621963501e+00" rms="9.8865842819213867e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="2" Cut="2.1623449325561523e+00" cType="1" res="1.4521782398223877e+00" rms="9.8428773880004883e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.4894657731056213e-01" rms="9.8123989105224609e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.6398500204086304e-01" rms="9.5131626129150391e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="4.0312301367521286e-02" cType="1" res="-2.2640180587768555e+00" rms="9.6815786361694336e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.5325148850679398e-02" rms="9.4656486511230469e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.9476158618927002e-01" rms="9.2069635391235352e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="41">
+      <Node pos="s" depth="0" NCoef="0" IVar="8" Cut="3.8373798131942749e-02" cType="1" res="4.2864341288805008e-02" rms="8.8492374420166016e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="11" Cut="2.2556996345520020e-01" cType="1" res="-2.3126557469367981e-01" rms="8.8106889724731445e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="3.8028985261917114e-02" cType="1" res="-1.0772205591201782e+00" rms="8.6854343414306641e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.5848892554640770e-03" rms="8.4653024673461914e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.3206722140312195e-01" rms="8.7069969177246094e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="7.6756995916366577e-01" cType="1" res="2.4407470226287842e-01" rms="8.8448600769042969e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.1835588142275810e-02" rms="8.8243417739868164e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2123763561248779e+00" rms="6.7512674331665039e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="13" Cut="3.4814281463623047e+01" cType="1" res="1.4617344141006470e+00" rms="8.9123773574829102e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="2" Cut="2.1715846061706543e+00" cType="1" res="1.1479992866516113e+00" rms="8.8308238983154297e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.6440321505069733e-01" rms="8.7889089584350586e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.6742873191833496e-01" rms="8.4731845855712891e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="2.7941295504570007e-01" cType="1" res="4.5743169784545898e+00" rms="9.1171102523803711e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.6881561279296875e-01" rms="9.3949794769287109e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.5720297098159790e+00" rms="3.6259984970092773e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="42">
+      <Node pos="s" depth="0" NCoef="0" IVar="2" Cut="-2.1715745925903320e+00" cType="1" res="1.7901289463043213e-01" rms="8.8373107910156250e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="9" Cut="6.8353211879730225e-01" cType="1" res="-3.5445303916931152e+00" rms="8.8237266540527344e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="5.9533208608627319e-01" cType="1" res="-4.5924339294433594e+00" rms="8.5556144714355469e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.5901784896850586e-01" rms="8.1118049621582031e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.8816446065902710e-01" rms="8.9048671722412109e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.0627297759056091e-01" rms="7.5269432067871094e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="2" Cut="1.9606126546859741e+00" cType="1" res="2.7642580866813660e-01" rms="8.8165826797485352e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="3.5580286383628845e-01" cType="1" res="4.1872963309288025e-01" rms="8.7764377593994141e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.0410753786563873e-02" rms="8.7305221557617188e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.8661254644393921e-01" rms="8.8036146163940430e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="2.7043694630265236e-02" cType="1" res="-2.5188071727752686e+00" rms="9.1320285797119141e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.5738762915134430e-02" rms="8.9140443801879883e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.6418850421905518e-01" rms="8.8563537597656250e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="43">
+      <Node pos="s" depth="0" NCoef="0" IVar="2" Cut="-1.9428459405899048e+00" cType="1" res="2.0549663901329041e-01" rms="8.8544158935546875e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="11" Cut="5.5001926422119141e-01" cType="1" res="-2.2952067852020264e+00" rms="9.0117931365966797e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="5.1770097017288208e-01" cType="1" res="-2.8780605792999268e+00" rms="8.7293939590454102e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.7612886428833008e-01" rms="8.4149646759033203e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.4185923337936401e-01" rms="8.6115894317626953e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="3.4407505393028259e-01" cType="1" res="2.2449166774749756e+00" rms="9.8478202819824219e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.6678206920623779e-02" rms="1.0987734794616699e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.4042656421661377e-01" rms="6.4793548583984375e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="15" Cut="5.5817955732345581e-01" cType="1" res="3.3360016345977783e-01" rms="8.8272237777709961e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="2" Cut="-7.0432007312774658e-01" cType="1" res="-8.4986671805381775e-02" rms="8.7647581100463867e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3770106434822083e-01" rms="8.8492364883422852e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.3874441683292389e-02" rms="8.6984138488769531e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="6" Cut="6.9908680915832520e+00" cType="1" res="1.1425333023071289e+00" rms="8.8910388946533203e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.2380384206771851e-02" rms="8.7302389144897461e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.1574499011039734e-01" rms="9.2334537506103516e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="44">
+      <Node pos="s" depth="0" NCoef="0" IVar="2" Cut="1.9427230358123779e+00" cType="1" res="1.6362521052360535e-01" rms="8.7925195693969727e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="9" Cut="3.8491854071617126e-01" cType="1" res="3.0132666230201721e-01" rms="8.7637548446655273e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="2" Cut="-1.9811670780181885e+00" cType="1" res="1.7650841474533081e+00" rms="9.0795087814331055e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.4582811594009399e-01" rms="9.1837491989135742e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.1462055444717407e-01" rms="8.9347476959228516e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="14" Cut="1.6893261671066284e+00" cType="1" res="4.2354334145784378e-03" rms="8.6681451797485352e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.1420309096574783e-02" rms="8.6888933181762695e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.6543799638748169e-01" rms="8.5266103744506836e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="10" Cut="2.7334380894899368e-02" cType="1" res="-2.5290191173553467e+00" rms="8.9197702407836914e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="1.1334867216646671e-02" cType="1" res="-2.7135798335075378e-01" rms="8.9923992156982422e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.2687444686889648e-01" rms="8.8865289688110352e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.1659939289093018e-01" rms="8.2674570083618164e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="3" Cut="5.9754978179931641e+01" cType="1" res="-4.0066242218017578e+00" rms="8.5552091598510742e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.1296131610870361e-01" rms="8.5164823532104492e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.6292761564254761e-01" rms="8.0866594314575195e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="45">
+      <Node pos="s" depth="0" NCoef="0" IVar="2" Cut="-2.1713542938232422e+00" cType="1" res="1.9525992870330811e-01" rms="8.7845268249511719e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="11" Cut="5.9533208608627319e-01" cType="1" res="-2.9946436882019043e+00" rms="8.7290592193603516e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="2" Cut="-2.2776937484741211e+00" cType="1" res="-3.6037242412567139e+00" rms="8.4368247985839844e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.4995970726013184e-01" rms="8.5311298370361328e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.4718153476715088e-01" rms="8.0951194763183594e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.9063411355018616e-01" rms="9.3858890533447266e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="14" Cut="1.4018542766571045e+00" cType="1" res="2.8658121824264526e-01" rms="8.7690401077270508e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="2" Cut="1.9643020629882812e+00" cType="1" res="6.5378266572952271e-01" rms="8.8054485321044922e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.5905872285366058e-02" rms="8.7793636322021484e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.7010738849639893e-01" rms="8.8453216552734375e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="6.4987175166606903e-02" cType="1" res="-5.3286892175674438e-01" rms="8.6310920715332031e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.4671515934169292e-03" rms="8.4071836471557617e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.9876476526260376e-01" rms="8.9548168182373047e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="46">
+      <Node pos="s" depth="0" NCoef="0" IVar="11" Cut="2.8011381626129150e-01" cType="1" res="7.6829522848129272e-02" rms="8.7327156066894531e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="10" Cut="3.8028985261917114e-02" cType="1" res="-5.5989056825637817e-01" rms="8.6066894531250000e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="9.3967723846435547e-01" cType="1" res="4.8952180147171021e-01" rms="8.4354953765869141e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.8000173196196556e-03" rms="8.3715953826904297e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.3708419799804688e-01" rms="8.4339733123779297e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="5" Cut="-9.4022857666015625e+01" cType="1" res="-1.4701857566833496e+00" rms="8.6499681472778320e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.0595278739929199e-01" rms="8.3249893188476562e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3477326137945056e-03" rms="9.1020956039428711e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="9" Cut="7.3016637563705444e-01" cType="1" res="8.0296921730041504e-01" rms="8.8183221817016602e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="4" Cut="6.2758092880249023e+00" cType="1" res="7.1348339319229126e-01" rms="8.8009281158447266e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.0431408882141113e-01" rms="8.2656250000000000e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4903517067432404e-01" rms="8.9154491424560547e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="7.4222493171691895e-01" cType="1" res="1.0790002822875977e+01" rms="3.3662497997283936e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.6745581626892090e+00" rms="4.2276563644409180e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.4264402389526367e+00" rms="7.1668499708175659e-01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="47">
+      <Node pos="s" depth="0" NCoef="0" IVar="4" Cut="2.1249221801757812e+01" cType="1" res="3.8203945755958557e-01" rms="8.7561788558959961e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="11" Cut="2.3342818021774292e-01" cType="1" res="6.6612958908081055e-02" rms="8.5260314941406250e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="8.6343479156494141e-01" cType="1" res="-8.2428634166717529e-01" rms="8.2881193161010742e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.6984876990318298e-01" rms="8.2770080566406250e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.3652108013629913e-01" rms="7.7711863517761230e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="7.4314147233963013e-01" cType="1" res="5.7847321033477783e-01" rms="8.6182098388671875e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.6773197352886200e-02" rms="8.6188907623291016e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.7529577016830444e-01" rms="7.4810800552368164e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="2" Cut="-1.9401835203170776e+00" cType="1" res="1.5287327766418457e+00" rms="9.4579887390136719e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="13" Cut="2.9548456192016602e+01" cType="1" res="-3.7871396541595459e+00" rms="9.0208368301391602e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.0910327434539795e-01" rms="8.5108070373535156e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.3696756362915039e-01" rms="8.6472196578979492e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="0" Cut="3.9500848388671875e+02" cType="1" res="1.7707071304321289e+00" rms="9.4061899185180664e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.7795332670211792e-01" rms="9.3909196853637695e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3041024208068848e+01" rms="7.2898526191711426e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="48">
+      <Node pos="s" depth="0" NCoef="0" IVar="3" Cut="1.7000878906250000e+02" cType="1" res="1.2761580944061279e-01" rms="8.7746706008911133e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="12" Cut="1.7428571701049805e+01" cType="1" res="5.6612575426697731e-03" rms="8.6841096878051758e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="5.6022763252258301e-01" cType="1" res="2.7305659651756287e-01" rms="8.6054410934448242e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.6172395125031471e-03" rms="8.5924320220947266e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.8392118215560913e-01" rms="8.5566616058349609e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="2" Cut="-1.2593418359756470e+00" cType="1" res="-9.5930910110473633e-01" rms="8.8956727981567383e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.8823933005332947e-01" rms="9.1605024337768555e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.1570765972137451e-01" rms="8.7748651504516602e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="10" Cut="2.5643590837717056e-02" cType="1" res="2.6834273338317871e+00" rms="1.0162963867187500e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="2.0266202092170715e-01" cType="1" res="4.1184201240539551e+00" rms="9.8578672409057617e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4056438207626343e+00" rms="7.6948838233947754e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.4732297658920288e-01" rms="1.0235074043273926e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="2.4548040330410004e-01" cType="1" res="1.4753109216690063e+00" rms="1.0258419990539551e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1189293116331100e-01" rms="1.0309990882873535e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7072515487670898e+00" rms="9.1212701797485352e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="49">
+      <Node pos="s" depth="0" NCoef="0" IVar="14" Cut="3.8170537948608398e+00" cType="1" res="1.1990584433078766e-01" rms="8.7982797622680664e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="8" Cut="3.9147228002548218e-02" cType="1" res="1.8657217919826508e-01" rms="8.7876453399658203e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="1.3534197211265564e-01" cType="1" res="-3.2634668052196503e-02" rms="8.7876987457275391e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.7432910203933716e-01" rms="8.3962697982788086e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.6388898044824600e-04" rms="8.8352174758911133e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="2" Cut="1.9205272197723389e+00" cType="1" res="1.3721181154251099e+00" rms="8.6920804977416992e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.0258648693561554e-01" rms="8.6455774307250977e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.8865128755569458e-01" rms="8.9807233810424805e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="13" Cut="5.4753501892089844e+01" cType="1" res="-4.8134026527404785e+00" rms="8.1598138809204102e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="4" Cut="1.9035528182983398e+01" cType="1" res="-3.2013382911682129e+00" rms="8.6378307342529297e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.4055752754211426e-01" rms="7.5930624008178711e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.8717269450426102e-02" rms="9.3429059982299805e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="2" Cut="1.5758274495601654e-01" cType="1" res="-8.1091785430908203e+00" rms="5.8302173614501953e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.4716204404830933e-01" rms="6.7735080718994141e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.5942296981811523e+00" rms="3.7126600742340088e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="50">
+      <Node pos="s" depth="0" NCoef="0" IVar="8" Cut="7.8294456005096436e-02" cType="1" res="2.8531150892376900e-02" rms="8.7084913253784180e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="3" Cut="4.1086004638671875e+02" cType="1" res="-1.6347983479499817e-01" rms="8.6916198730468750e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="9.3625676631927490e-01" cType="1" res="-1.9344289600849152e-01" rms="8.6786661148071289e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.9571830779314041e-02" rms="8.6664848327636719e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.7225390672683716e-01" rms="8.5050792694091797e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.0694727897644043e+00" rms="7.5390024185180664e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="3" Cut="8.2600746154785156e+01" cType="1" res="1.2961181402206421e+00" rms="8.7135372161865234e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="2" Cut="-5.7102656364440918e-01" cType="1" res="6.9959568977355957e-01" rms="8.4890966415405273e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.3525430262088776e-01" rms="8.3347301483154297e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.6437455564737320e-03" rms="8.5058584213256836e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="4" Cut="4.9687500000000000e+01" cType="1" res="3.5007483959197998e+00" rms="9.1662225723266602e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.7596632242202759e-01" rms="8.9458789825439453e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.9705070257186890e-01" rms="9.0039796829223633e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="51">
+      <Node pos="s" depth="0" NCoef="0" IVar="2" Cut="2.1710932254791260e+00" cType="1" res="2.4860443174839020e-01" rms="8.7335062026977539e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="15" Cut="1.0163264274597168e+00" cType="1" res="3.2778427004814148e-01" rms="8.7271947860717773e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="8.3399604797363281e+01" cType="1" res="6.4175136387348175e-02" rms="8.6434106826782227e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.7690957784652710e-02" rms="8.3193244934082031e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.0406240224838257e-01" rms="9.6099052429199219e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="2" Cut="-1.9555150270462036e+00" cType="1" res="1.2731453180313110e+00" rms="8.9576969146728516e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.2205275297164917e-01" rms="8.7138776779174805e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.2451360523700714e-01" rms="8.9338932037353516e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="1" Cut="2.2811132431030273e+01" cType="1" res="-3.1676826477050781e+00" rms="8.3118991851806641e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="12" Cut="1.2523809432983398e+01" cType="1" res="-2.2404768466949463e+00" rms="8.4176216125488281e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.5530760288238525e-01" rms="7.7073941230773926e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.3596441149711609e-01" rms="9.2055292129516602e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="1.2476190567016602e+01" cType="1" res="-7.1504530906677246e+00" rms="6.4757275581359863e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.6413853168487549e-01" rms="6.2280149459838867e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.4833687543869019e+00" rms="5.8803353309631348e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="52">
+      <Node pos="s" depth="0" NCoef="0" IVar="2" Cut="-2.1713886260986328e+00" cType="1" res="5.4920688271522522e-02" rms="8.6433420181274414e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="13" Cut="2.7738115310668945e+01" cType="1" res="-3.1453168392181396e+00" rms="8.8313989639282227e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="6.7318099975585938e+01" cType="1" res="-3.8574311733245850e+00" rms="8.4068355560302734e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.3455896377563477e-01" rms="8.4423618316650391e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.0685268640518188e+00" rms="7.1316218376159668e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.2858512401580811e-01" rms="9.9891452789306641e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="14" Cut="2.6425757408142090e+00" cType="1" res="1.3695350289344788e-01" rms="8.6228694915771484e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="13" Cut="3.5466827392578125e+01" cType="1" res="2.8151860833168030e-01" rms="8.6300287246704102e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.5803395807743073e-03" rms="8.5737257003784180e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.7189349532127380e-01" rms="9.0932083129882812e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="8" Cut="2.9121480882167816e-02" cType="1" res="-1.3077462911605835e+00" rms="8.4156684875488281e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.4361808598041534e-01" rms="8.2566862106323242e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.7627655863761902e-01" rms="8.8217897415161133e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="53">
+      <Node pos="s" depth="0" NCoef="0" IVar="3" Cut="4.0968725585937500e+02" cType="1" res="1.0365271568298340e-01" rms="8.7202997207641602e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="11" Cut="1.4005690813064575e-01" cType="1" res="7.7311381697654724e-02" rms="8.7093229293823242e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="9.5663273334503174e-01" cType="1" res="-9.2143130302429199e-01" rms="8.5816078186035156e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.7316009104251862e-01" rms="8.5384616851806641e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.1531006097793579e-01" rms="7.7184143066406250e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="8.1488138437271118e-01" cType="1" res="2.8816363215446472e-01" rms="8.7214374542236328e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0492131114006042e-03" rms="8.7208585739135742e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.2881044149398804e-01" rms="7.9999141693115234e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.3306093215942383e+00" rms="6.5950350761413574e+00" purity="1.0000000000000000e+00" nType="-99"/>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="54">
+      <Node pos="s" depth="0" NCoef="0" IVar="11" Cut="4.6685636043548584e-01" cType="1" res="1.3099507987499237e-01" rms="8.7511930465698242e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="5" Cut="-9.3654830932617188e+01" cType="1" res="-3.5500194877386093e-02" rms="8.7168455123901367e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="7.3800975084304810e-01" cType="1" res="-3.8342288136482239e-01" rms="8.4693422317504883e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.4081001281738281e-01" rms="8.5682544708251953e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.7816356420516968e-02" rms="8.1667509078979492e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="1.9925358891487122e-01" cType="1" res="7.5350755453109741e-01" rms="9.2050333023071289e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.1571821570396423e-02" rms="9.1272678375244141e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.4615670442581177e-01" rms="9.5837717056274414e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="9" Cut="4.6398478746414185e-01" cType="1" res="1.2325742244720459e+00" rms="8.8969755172729492e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="2" Cut="-2.1657629013061523e+00" cType="1" res="5.2557486295700073e-01" rms="8.8868083953857422e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.2691826820373535e-01" rms="9.3036489486694336e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.6688240766525269e-02" rms="8.8087329864501953e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="5.3707474470138550e-01" cType="1" res="3.8917725086212158e+00" rms="8.4193172454833984e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.7258124351501465e-01" rms="8.3982963562011719e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.5637283325195312e+00" rms="2.3888161182403564e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="55">
+      <Node pos="s" depth="0" NCoef="0" IVar="9" Cut="8.8311034440994263e-01" cType="1" res="-9.5872700214385986e-02" rms="8.7255983352661133e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="11" Cut="1.3342607021331787e-01" cType="1" res="-1.8896307051181793e-01" rms="8.7249355316162109e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="8" Cut="1.5658891201019287e-01" cType="1" res="-1.5028259754180908e+00" rms="8.7783613204956055e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.7051523327827454e-01" rms="8.3999423980712891e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.5420031100511551e-03" rms="9.7119560241699219e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="7" Cut="-9.4267890930175781e+01" cType="1" res="3.6698253825306892e-03" rms="8.7004137039184570e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.7294081896543503e-02" rms="8.5361843109130859e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0777139663696289e-01" rms="9.1093521118164062e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="11" Cut="1.0998206585645676e-01" cType="1" res="2.2776916027069092e+00" rms="8.4009532928466797e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="2.3781152442097664e-02" cType="1" res="1.0629910230636597e+00" rms="8.3161582946777344e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.3735757470130920e-02" rms="8.1615800857543945e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.6574269533157349e-01" rms="7.7991313934326172e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="9.0239453315734863e-01" cType="1" res="7.8934822082519531e+00" rms="6.2266273498535156e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.8044579029083252e-01" rms="6.6282010078430176e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.8927273750305176e+00" rms="7.7239131927490234e-01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="56">
+      <Node pos="s" depth="0" NCoef="0" IVar="15" Cut="1.1163591146469116e+00" cType="1" res="1.1209964752197266e-01" rms="8.6790218353271484e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="12" Cut="3.1714284896850586e+01" cType="1" res="-1.1982893943786621e-01" rms="8.5892219543457031e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="2.2976872324943542e-01" cType="1" res="-1.5501438081264496e-01" rms="8.5752105712890625e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.7530071586370468e-02" rms="8.5257368087768555e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.3725210130214691e-01" rms="8.9089050292968750e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.8342635631561279e+00" rms="7.8279714584350586e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="10" Cut="3.4547008574008942e-02" cType="1" res="1.0238618850708008e+00" rms="8.9654207229614258e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="16" Cut="3.0000000000000000e+00" cType="1" res="1.8298375606536865e+00" rms="8.5737104415893555e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.2742612957954407e-01" rms="8.8840599060058594e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.9234640896320343e-01" rms="8.6579952239990234e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="2" Cut="1.9401448965072632e+00" cType="1" res="2.0468172430992126e-01" rms="9.0721054077148438e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.1088880300521851e-02" rms="9.0470027923583984e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.7475597262382507e-01" rms="8.5994844436645508e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="57">
+      <Node pos="s" depth="0" NCoef="0" IVar="11" Cut="1.7749142646789551e-01" cType="1" res="5.1753617823123932e-02" rms="8.6365690231323242e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="9" Cut="9.6012318134307861e-01" cType="1" res="-7.9931586980819702e-01" rms="8.4592256546020508e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="8" Cut="3.8917224854230881e-02" cType="1" res="-9.1089481115341187e-01" rms="8.4312438964843750e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.8420061469078064e-01" rms="8.2142114639282227e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.5591073334217072e-02" rms="8.9996385574340820e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="3.7729009985923767e-02" cType="1" res="5.3352022171020508e+00" rms="7.6958670616149902e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.2615037858486176e-01" rms="8.0512008666992188e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.0691382884979248e+00" rms="5.7382283210754395e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="9" Cut="8.2908099889755249e-01" cType="1" res="3.4667542576789856e-01" rms="8.6777276992797852e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="6" Cut="-7.2161560058593750e+01" cType="1" res="2.8000560402870178e-01" rms="8.6652679443359375e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.0087191611528397e-02" rms="8.4443550109863281e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.0119670033454895e-01" rms="9.2067670822143555e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="1.8628644943237305e-01" cType="1" res="9.8532991409301758e+00" rms="3.8867876529693604e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.4299274682998657e-01" rms="4.7203764915466309e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.0467412471771240e+00" rms="1.7646107673645020e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="58">
+      <Node pos="s" depth="0" NCoef="0" IVar="2" Cut="-2.1713886260986328e+00" cType="1" res="1.3138562440872192e-01" rms="8.5899200439453125e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="16" Cut="4.0000000000000000e+00" cType="1" res="-2.6369030475616455e+00" rms="8.5534334182739258e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="6.2880653142929077e-01" cType="1" res="-3.7765030860900879e+00" rms="8.5869112014770508e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.1803224086761475e-01" rms="8.3997364044189453e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.9460048079490662e-02" rms="8.4993448257446289e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="4" Cut="1.0324776649475098e+01" cType="1" res="2.6320141553878784e-01" rms="8.9636487960815430e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.8414680361747742e-01" rms="8.4864311218261719e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.7305675745010376e-01" rms="7.7695388793945312e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="8" Cut="1.0419321060180664e-01" cType="1" res="2.1454581618309021e-01" rms="8.5688047409057617e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="2.3342818021774292e-01" cType="1" res="5.5681638419628143e-02" rms="8.5560283660888672e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.9431392252445221e-02" rms="8.4161643981933594e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.4127723425626755e-02" rms="8.6251878738403320e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="4" Cut="9.4754467010498047e+00" cType="1" res="1.5383163690567017e+00" rms="8.5606594085693359e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.0266612321138382e-02" rms="7.7361946105957031e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.8277722001075745e-01" rms="8.7099647521972656e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="59">
+      <Node pos="s" depth="0" NCoef="0" IVar="15" Cut="1.1163591146469116e+00" cType="1" res="1.7964579164981842e-01" rms="8.6693563461303711e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="2" Cut="-2.1666052341461182e+00" cType="1" res="-9.6182823181152344e-02" rms="8.5629148483276367e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="6.2565439939498901e-01" cType="1" res="-3.9126505851745605e+00" rms="8.0588960647583008e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.5076059103012085e-01" rms="7.9669246673583984e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.9470466375350952e-02" rms="6.6790380477905273e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="9.3188661336898804e-01" cType="1" res="-1.8998932093381882e-02" rms="8.5552558898925781e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.0984127894043922e-02" rms="8.5415058135986328e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.1823996305465698e-01" rms="8.6224937438964844e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="11" Cut="8.9568011462688446e-02" cType="1" res="1.2928112745285034e+00" rms="9.0007781982421875e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="7.3537677526473999e-02" cType="1" res="-1.4024693965911865e+00" rms="8.9298028945922852e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.5086887478828430e-01" rms="8.3888301849365234e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.4254949688911438e-01" rms="9.0236759185791016e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="2" Cut="-1.9383840560913086e+00" cType="1" res="1.5687061548233032e+00" rms="8.9623966217041016e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.9787414073944092e-02" rms="8.7186641693115234e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.7610316872596741e-01" rms="8.9531126022338867e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="60">
+      <Node pos="s" depth="0" NCoef="0" IVar="11" Cut="1.8674254417419434e-01" cType="1" res="1.6902852058410645e-01" rms="8.6418762207031250e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="9" Cut="8.5280007123947144e-01" cType="1" res="-5.8112078905105591e-01" rms="8.4689407348632812e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="8" Cut="7.6023474335670471e-02" cType="1" res="-1.0226649045944214e+00" rms="8.5294342041015625e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.2546109557151794e-01" rms="8.3800354003906250e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.9822878092527390e-02" rms="8.7802162170410156e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="1.5112438797950745e-01" cType="1" res="9.3931537866592407e-01" rms="8.0745935440063477e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.1259918808937073e-02" rms="7.9408402442932129e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.6451934576034546e+00" rms="3.8005506992340088e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="9" Cut="7.8352445363998413e-01" cType="1" res="4.7324499487876892e-01" rms="8.6925992965698242e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="8" Cut="4.6880042552947998e-01" cType="1" res="3.2609191536903381e-01" rms="8.7063341140747070e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.2190181538462639e-02" rms="8.6999111175537109e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.9742536544799805e+00" rms="6.5144495964050293e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="8.1777918338775635e-01" cType="1" res="4.4147257804870605e+00" rms="7.2832279205322266e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.4379786252975464e-01" rms="7.2120342254638672e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7615661621093750e+00" rms="3.8355391025543213e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="61">
+      <Node pos="s" depth="0" NCoef="0" IVar="2" Cut="2.1709208488464355e+00" cType="1" res="2.1953541040420532e-01" rms="8.5875473022460938e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="9" Cut="9.8826467990875244e-01" cType="1" res="2.9939961433410645e-01" rms="8.5766038894653320e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="14" Cut="1.4077718257904053e+00" cType="1" res="2.7787283062934875e-01" rms="8.5704689025878906e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.9665454328060150e-02" rms="8.6384992599487305e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.3251634836196899e-02" rms="8.3770389556884766e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.0875391960144043e+00" rms="5.0031561851501465e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="9" Cut="5.6020796298980713e-01" cType="1" res="-3.0831620693206787e+00" rms="8.3870325088500977e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="2" Cut="2.2147450447082520e+00" cType="1" res="-4.0400266647338867e+00" rms="8.2583074569702148e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.6351795792579651e-03" rms="8.7410545349121094e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.0737504959106445e-01" rms="7.7918024063110352e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="2" Cut="2.2625365257263184e+00" cType="1" res="-9.9041886627674103e-02" rms="8.0786237716674805e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.9516318440437317e-01" rms="6.8250689506530762e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.3778889179229736e-01" rms="8.4007549285888672e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="62">
+      <Node pos="s" depth="0" NCoef="0" IVar="3" Cut="1.2175665283203125e+02" cType="1" res="1.3888202607631683e-01" rms="8.5182857513427734e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="11" Cut="8.8950715959072113e-02" cType="1" res="-2.8564259409904480e-02" rms="8.2899560928344727e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="9.5663273334503174e-01" cType="1" res="-1.4522984027862549e+00" rms="8.0179443359375000e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.4200718104839325e-01" rms="7.9105973243713379e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.4697386622428894e-01" rms="8.0036859512329102e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="8.4638595581054688e-01" cType="1" res="8.2696206867694855e-02" rms="8.3005571365356445e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.6229809969663620e-02" rms="8.3141155242919922e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.1492879986763000e-01" rms="7.5914564132690430e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="16" Cut="4.0000000000000000e+00" cType="1" res="1.3851112127304077e+00" rms="1.0032334327697754e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="1.9163284301757812e+01" cType="1" res="2.1722700595855713e+00" rms="1.0086427688598633e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.2784018516540527e-01" rms="9.8522434234619141e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.9834860563278198e-01" rms="1.0264850616455078e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="1.4940716743469238e+01" cType="1" res="-6.1202383041381836e-01" rms="9.7966909408569336e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.9098094701766968e-01" rms="7.6519217491149902e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.1740367412567139e-02" rms="1.0085064888000488e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="63">
+      <Node pos="s" depth="0" NCoef="0" IVar="13" Cut="4.7289104461669922e+01" cType="1" res="1.4521111547946930e-01" rms="8.5161962509155273e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="4" Cut="1.0841285705566406e+01" cType="1" res="1.4639380387961864e-02" rms="8.4661750793457031e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="13" Cut="3.0706481933593750e+01" cType="1" res="-4.2980092763900757e-01" rms="7.9392576217651367e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.2279363870620728e-02" rms="7.9290781021118164e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.0960187911987305e-01" rms="7.1851429939270020e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="14" Cut="1.3906620740890503e+00" cType="1" res="3.9032834768295288e-01" rms="8.8698987960815430e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.4925187528133392e-02" rms="9.0140972137451172e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.2071170210838318e-02" rms="8.4906845092773438e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="0" Cut="7.9598670959472656e+01" cType="1" res="2.4148275852203369e+00" rms="9.0467576980590820e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="12" Cut="1.1857142448425293e+01" cType="1" res="5.4393463134765625e+00" rms="7.2216410636901855e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.5492224693298340e+00" rms="3.9340794086456299e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.3776736259460449e-01" rms="7.8037524223327637e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="8.0099925398826599e-02" cType="1" res="1.9180771112442017e+00" rms="9.2179841995239258e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.2617989182472229e-01" rms="8.6418256759643555e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.2258504033088684e-01" rms="9.1657772064208984e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="64">
+      <Node pos="s" depth="0" NCoef="0" IVar="0" Cut="5.8797317504882812e+01" cType="1" res="4.1774060577154160e-02" rms="8.5347089767456055e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="13" Cut="2.1609430313110352e+01" cType="1" res="-3.5350108146667480e-01" rms="7.9208102226257324e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="3.6091193556785583e-01" cType="1" res="-6.8931138515472412e-01" rms="7.8507533073425293e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.4799708127975464e-01" rms="7.7538666725158691e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.0154176577925682e-03" rms="7.9881358146667480e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="3.7134137749671936e-01" cType="1" res="1.8996012210845947e+00" rms="8.0199422836303711e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7450922727584839e-01" rms="7.9695987701416016e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1212859153747559e+00" rms="6.9220743179321289e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="14" Cut="1.4680975675582886e+00" cType="1" res="4.7825363278388977e-01" rms="9.1451244354248047e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="2" Cut="-1.9435436725616455e+00" cType="1" res="9.3341094255447388e-01" rms="9.1768054962158203e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.0253824591636658e-01" rms="8.7335577011108398e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.6102027893066406e-01" rms="9.1679267883300781e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="2.7507926940917969e+01" cType="1" res="-3.9502578973770142e-01" rms="9.0199508666992188e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.0065053403377533e-01" rms="8.9851627349853516e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.6368702650070190e-01" rms="8.9245862960815430e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="65">
+      <Node pos="s" depth="0" NCoef="0" IVar="2" Cut="-2.1679408550262451e+00" cType="1" res="1.6688100993633270e-01" rms="8.5635576248168945e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="9" Cut="7.2053080797195435e-01" cType="1" res="-2.4567415714263916e+00" rms="8.4220170974731445e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="6.1868801116943359e+01" cType="1" res="-2.9839789867401123e+00" rms="8.2757711410522461e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.7506190538406372e-01" rms="7.8750672340393066e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.2990504503250122e-01" rms="8.5925884246826172e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.6001650094985962e-01" rms="8.3478240966796875e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="2" Cut="2.1820752620697021e+00" cType="1" res="2.4300821125507355e-01" rms="8.5556278228759766e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="2" Cut="1.3531596660614014e+00" cType="1" res="3.0502349138259888e-01" rms="8.5474214553833008e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.9075781181454659e-03" rms="8.5322275161743164e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.1634812653064728e-01" rms="8.5273723602294922e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="5.4087389260530472e-02" cType="1" res="-2.2793791294097900e+00" rms="8.5081510543823242e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.9176979809999466e-02" rms="8.9786071777343750e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.3560900688171387e-01" rms="7.8087410926818848e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="66">
+      <Node pos="s" depth="0" NCoef="0" IVar="2" Cut="1.9384573698043823e+00" cType="1" res="1.6732737421989441e-02" rms="8.6034793853759766e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="2" Cut="1.3172723054885864e+00" cType="1" res="1.1802692711353302e-01" rms="8.6007041931152344e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="1.7800503969192505e-01" cType="1" res="-5.6070361286401749e-02" rms="8.5658645629882812e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.5299164950847626e-02" rms="8.5318546295166016e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3153909146785736e-01" rms="8.7284317016601562e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="3.7277159094810486e-01" cType="1" res="1.5485749244689941e+00" rms="8.7516212463378906e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0371256619691849e-01" rms="8.8048610687255859e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.0022920370101929e-01" rms="8.0730094909667969e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="3" Cut="6.1711681365966797e+01" cType="1" res="-2.1821951866149902e+00" rms="8.3665122985839844e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="5.3395158052444458e-01" cType="1" res="-1.1545766592025757e+00" rms="7.8574504852294922e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.2259303927421570e-01" rms="7.6055488586425781e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.5974025726318359e-01" rms="8.3294448852539062e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="6" Cut="-9.1424453735351562e+01" cType="1" res="-3.3649260997772217e+00" rms="8.7686891555786133e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.5889012813568115e-01" rms="8.3374814987182617e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.6777653023600578e-02" rms="9.3736400604248047e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="67">
+      <Node pos="s" depth="0" NCoef="0" IVar="14" Cut="1.6173282861709595e+00" cType="1" res="1.8838010728359222e-01" rms="8.6474647521972656e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="2" Cut="2.1709208488464355e+00" cType="1" res="4.5863652229309082e-01" rms="8.6727914810180664e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="2" Cut="1.0798407793045044e+00" cType="1" res="5.2057051658630371e-01" rms="8.6680021286010742e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.4066297337412834e-02" rms="8.6285200119018555e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.0885880291461945e-01" rms="8.7600822448730469e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="6.1383181810379028e-01" cType="1" res="-2.0813386440277100e+00" rms="8.4861650466918945e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.3623569607734680e-01" rms="7.9916362762451172e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.7351444959640503e-01" rms="7.6826128959655762e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="13" Cut="5.3582809448242188e+01" cType="1" res="-5.9404337406158447e-01" rms="8.5255498886108398e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="6" Cut="5.5478429794311523e+00" cType="1" res="-8.8581848144531250e-01" rms="8.3446865081787109e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.7767348885536194e-01" rms="8.1717786788940430e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.4693773351609707e-02" rms="8.6692581176757812e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="2.1862553432583809e-02" cType="1" res="1.2971220016479492e+00" rms="9.3985834121704102e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.4310381412506104e-01" rms="9.0282039642333984e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.9840952008962631e-02" rms="9.4191856384277344e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="68">
+      <Node pos="s" depth="0" NCoef="0" IVar="5" Cut="-9.3795089721679688e+01" cType="1" res="8.1596203148365021e-02" rms="8.6096391677856445e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="9" Cut="7.8198927640914917e-01" cType="1" res="-1.7436671257019043e-01" rms="8.3429479598999023e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="2.2186428308486938e-01" cType="1" res="-3.9396658539772034e-01" rms="8.3878993988037109e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.5999334454536438e-01" rms="8.0843877792358398e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.1076280623674393e-02" rms="8.4185791015625000e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="2.1062457561492920e-01" cType="1" res="7.7564144134521484e-01" rms="8.0771389007568359e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.5723909735679626e-02" rms="8.0389337539672852e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.4065552949905396e-01" rms="6.6112794876098633e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="4" Cut="3.0495162963867188e+01" cType="1" res="7.2832274436950684e-01" rms="9.2176618576049805e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="6" Cut="2.9657339096069336e+01" cType="1" res="4.1783213615417480e-01" rms="9.0999803543090820e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.2192391604185104e-02" rms="9.0917682647705078e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.0491911768913269e-01" rms="8.7801904678344727e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="7" Cut="1.8086714670062065e-02" cType="1" res="2.6208007335662842e+00" rms="9.6920137405395508e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.3004180192947388e-01" rms="1.0283856391906738e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.8011248111724854e-01" rms="9.4357404708862305e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="69">
+      <Node pos="s" depth="0" NCoef="0" IVar="12" Cut="1.3190476417541504e+01" cType="1" res="8.1773556768894196e-02" rms="8.5853548049926758e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="13" Cut="7.2887496948242188e+01" cType="1" res="5.4184120893478394e-01" rms="8.3393821716308594e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="6.0828185081481934e-01" cType="1" res="5.0237733125686646e-01" rms="8.3288717269897461e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.4977879375219345e-02" rms="8.3188838958740234e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.9905310273170471e-01" rms="8.2991561889648438e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3113420009613037e+00" rms="8.1932744979858398e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="2" Cut="-1.0285145044326782e+00" cType="1" res="-3.1570214033126831e-01" rms="8.7729187011718750e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="2" Cut="-1.8109326362609863e+00" cType="1" res="1.0499373674392700e+00" rms="9.0207223892211914e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.0447234809398651e-01" rms="9.1464986801147461e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.7441519498825073e-01" rms="8.8415851593017578e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="6" Cut="7.4362106323242188e+01" cType="1" res="-6.2527143955230713e-01" rms="8.6859645843505859e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.8940469324588776e-02" rms="8.6766576766967773e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.2101626396179199e+00" rms="8.0395507812500000e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="70">
+      <Node pos="s" depth="0" NCoef="0" IVar="14" Cut="2.8037085533142090e+00" cType="1" res="1.2015693634748459e-01" rms="8.5625820159912109e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="2" Cut="-1.2572182416915894e+00" cType="1" res="2.6610568165779114e-01" rms="8.5670223236083984e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="2" Cut="-2.0195400714874268e+00" cType="1" res="1.3730479478836060e+00" rms="8.6367235183715820e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.5862661004066467e-02" rms="8.6002378463745117e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.7795854210853577e-01" rms="8.5551977157592773e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="13" Cut="7.6776268005371094e+01" cType="1" res="2.7471384033560753e-02" rms="8.5331277847290039e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.0492516458034515e-02" rms="8.5145454406738281e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4985707998275757e+00" rms="9.1681671142578125e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="2" Cut="1.4642032384872437e+00" cType="1" res="-1.7867171764373779e+00" rms="8.2710075378417969e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="1.1111550331115723e+01" cType="1" res="-2.1853220462799072e+00" rms="8.0207853317260742e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.3850740790367126e-01" rms="6.9706072807312012e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.2881963253021240e-01" rms="7.9752359390258789e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="2" Cut="1.7659816741943359e+00" cType="1" res="1.9682548046112061e+00" rms="9.5506734848022461e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.5853753089904785e+00" rms="7.5796480178833008e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.5551447272300720e-01" rms="9.2396478652954102e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="71">
+      <Node pos="s" depth="0" NCoef="0" IVar="2" Cut="-1.2533261775970459e+00" cType="1" res="7.1214772760868073e-02" rms="8.4939517974853516e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="11" Cut="2.9329833388328552e-01" cType="1" res="9.6727049350738525e-01" rms="8.6140241622924805e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="7.5349617004394531e-01" cType="1" res="1.4616896212100983e-01" rms="8.4544172286987305e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.2934596836566925e-01" rms="8.5273771286010742e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.3220500349998474e-01" rms="8.0327062606811523e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="2" Cut="-1.8513755798339844e+00" cType="1" res="2.0399661064147949e+00" rms="8.7022371292114258e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.0433935374021530e-02" rms="8.7857637405395508e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.5366396903991699e-01" rms="8.3131685256958008e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="12" Cut="1.0428571701049805e+01" cType="1" res="-1.1495041102170944e-01" rms="8.4568891525268555e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="2" Cut="2.0480661392211914e+00" cType="1" res="8.5309267044067383e-01" rms="8.3149566650390625e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3788129389286041e-01" rms="8.3415222167968750e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.8400466442108154e-01" rms="7.7251939773559570e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="15" Cut="1.0699802637100220e+00" cType="1" res="-3.4729185700416565e-01" rms="8.4741611480712891e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.9659631252288818e-02" rms="8.3704261779785156e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0388392210006714e-01" rms="8.8815212249755859e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="72">
+      <Node pos="s" depth="0" NCoef="0" IVar="2" Cut="-1.0286499261856079e+00" cType="1" res="1.5517155826091766e-01" rms="8.5169887542724609e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="2" Cut="-2.0082087516784668e+00" cType="1" res="9.3292033672332764e-01" rms="8.7732200622558594e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="7.3316454887390137e-01" cType="1" res="-1.0882970094680786e+00" rms="8.6294555664062500e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.6721253991127014e-01" rms="8.5151786804199219e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.3856744766235352e-01" rms="7.4158830642700195e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="1.3913613557815552e-01" cType="1" res="1.4374021291732788e+00" rms="8.7361135482788086e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.7632991075515747e-01" rms="8.5630531311035156e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.9428139328956604e-01" rms="8.6590995788574219e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="10" Cut="1.4240403473377228e-01" cType="1" res="-6.6013351082801819e-02" rms="8.4296026229858398e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="15" Cut="5.5817955732345581e-01" cType="1" res="-2.7814987301826477e-01" rms="8.3560266494750977e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.8090039789676666e-02" rms="8.1665334701538086e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.1615374833345413e-02" rms="8.7228622436523438e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="14" Cut="1.0271475315093994e+00" cType="1" res="9.1814643144607544e-01" rms="8.6954269409179688e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.5258874893188477e-01" rms="8.4936265945434570e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.6910621523857117e-01" rms="8.8191900253295898e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="73">
+      <Node pos="s" depth="0" NCoef="0" IVar="11" Cut="6.3159590959548950e-01" cType="1" res="7.1484491229057312e-02" rms="8.5231781005859375e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="0" Cut="3.8960470581054688e+02" cType="1" res="-9.1379582881927490e-03" rms="8.5122499465942383e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="12" Cut="1.6857143402099609e+01" cType="1" res="-2.9030593112111092e-02" rms="8.5046157836914062e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.5717703849077225e-02" rms="8.4033041000366211e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.1471822857856750e-01" rms="8.6976671218872070e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.4368104934692383e+00" rms="6.9385037422180176e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="9" Cut="2.7664637565612793e-01" cType="1" res="2.6067235469818115e+00" rms="8.4774265289306641e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="1.8582479476928711e+01" cType="1" res="5.7603639364242554e-01" rms="8.8696060180664062e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.8943568468093872e-01" rms="8.9400386810302734e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.1902095675468445e-01" rms="8.2645635604858398e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="4.3324615806341171e-02" cType="1" res="4.5512604713439941e+00" rms="7.5909328460693359e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.7307574748992920e-01" rms="7.6762142181396484e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.9283722639083862e+00" rms="4.4631304740905762e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="74">
+      <Node pos="s" depth="0" NCoef="0" IVar="9" Cut="8.9871597290039062e-01" cType="1" res="1.4764207601547241e-01" rms="8.5581493377685547e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="14" Cut="2.9361951351165771e+00" cType="1" res="9.0416677296161652e-02" rms="8.5631761550903320e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="13" Cut="3.0710506439208984e+01" cType="1" res="1.8300940096378326e-01" rms="8.5599641799926758e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.3167955055832863e-03" rms="8.4579830169677734e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.8379575014114380e-01" rms="9.2411375045776367e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="3.6334282159805298e-01" cType="1" res="-1.4818439483642578e+00" rms="8.4642887115478516e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.5275164842605591e-01" rms="8.2740163803100586e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.8997956514358521e-01" rms="9.4528264999389648e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="11" Cut="1.0273527354001999e-01" cType="1" res="2.1801512241363525e+00" rms="8.1202173233032227e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="9.9119764566421509e-01" cType="1" res="1.0965775251388550e+00" rms="7.9567990303039551e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.0030890405178070e-02" rms="7.8611145019531250e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.9811910390853882e+00" rms="7.3557534217834473e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.6493951082229614e+00" rms="4.4975490570068359e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="75">
+      <Node pos="s" depth="0" NCoef="0" IVar="11" Cut="6.7694681882858276e-01" cType="1" res="1.0433463007211685e-01" rms="8.5323257446289062e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="2" Cut="1.9422717094421387e+00" cType="1" res="5.7017564773559570e-02" rms="8.5219640731811523e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="2" Cut="1.1145111322402954e+00" cType="1" res="1.3947969675064087e-01" rms="8.5115718841552734e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.1301547065377235e-02" rms="8.4352512359619141e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2801857292652130e-01" rms="8.8537120819091797e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="5.4777806997299194e-01" cType="1" res="-1.5867044925689697e+00" rms="8.5624284744262695e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.1494206190109253e-01" rms="8.3473434448242188e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.1191651821136475e-01" rms="9.2124195098876953e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="4" Cut="3.3164062500000000e+00" cType="1" res="3.5351648330688477e+00" rms="8.5836973190307617e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.0258244723081589e-01" rms="5.5521812438964844e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="1.5115393638610840e+01" cType="1" res="4.8428649902343750e+00" rms="8.8590431213378906e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.2492246180772781e-01" rms="9.6150579452514648e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2852694988250732e+00" rms="7.7779760360717773e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="76">
+      <Node pos="s" depth="0" NCoef="0" IVar="11" Cut="4.3532777577638626e-02" cType="1" res="1.4839901030063629e-01" rms="8.5578441619873047e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="5" Cut="-9.4149009704589844e+01" cType="1" res="-3.5784101486206055e+00" rms="8.2864179611206055e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="1.8632268533110619e-02" cType="1" res="-5.9942536354064941e+00" rms="6.7070994377136230e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.0926235914230347e+00" rms="6.3990707397460938e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.0429960489273071e-01" rms="6.6060328483581543e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="4" Cut="2.3793527603149414e+01" cType="1" res="-8.0018997192382812e-01" rms="9.0258483886718750e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.6815989613533020e-01" rms="9.4785842895507812e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.6843668222427368e-01" rms="6.4615287780761719e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="3" Cut="3.0488647460937500e+02" cType="1" res="2.1167126297950745e-01" rms="8.5483636856079102e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="12" Cut="1.3142857551574707e+01" cType="1" res="1.7177578806877136e-01" rms="8.5233783721923828e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.3890142142772675e-02" rms="8.3688945770263672e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.6338947266340256e-02" rms="8.6344614028930664e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="15" Cut="3.4055632352828979e-01" cType="1" res="5.4899482727050781e+00" rms="1.0071504592895508e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4543418884277344e+00" rms="1.1251703262329102e+01" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.5528099536895752e+00" rms="5.3231444358825684e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="77">
+      <Node pos="s" depth="0" NCoef="0" IVar="11" Cut="4.5113991945981979e-02" cType="1" res="5.9554323554039001e-02" rms="8.5265378952026367e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="2" Cut="8.9231884479522705e-01" cType="1" res="-2.9003560543060303e+00" rms="8.3496246337890625e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="9.1346077620983124e-02" cType="1" res="-9.3025219440460205e-01" rms="8.0885410308837891e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.6621570140123367e-02" rms="8.0908021926879883e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.5752784013748169e-01" rms="6.5572681427001953e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="1.7182022094726562e+01" cType="1" res="-6.4768524169921875e+00" rms="7.5940747261047363e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.3167023658752441e+00" rms="4.5628242492675781e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.7754458189010620e-01" rms="8.0376567840576172e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="3" Cut="4.1086004638671875e+02" cType="1" res="1.1247182637453079e-01" rms="8.5203161239624023e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="2" Cut="-1.2572182416915894e+00" cType="1" res="9.4878755509853363e-02" rms="8.5129051208496094e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0854041576385498e-01" rms="8.6397171020507812e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.6037210598587990e-02" rms="8.4787054061889648e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.5844193458557129e+01" rms="8.3748950958251953e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="78">
+      <Node pos="s" depth="0" NCoef="0" IVar="11" Cut="3.7348508834838867e-01" cType="1" res="6.6496677696704865e-02" rms="8.4453697204589844e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="9" Cut="7.3316454887390137e-01" cType="1" res="-2.0986081659793854e-01" rms="8.3626937866210938e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="6" Cut="5.1326227188110352e+00" cType="1" res="-4.8942023515701294e-01" rms="8.5554304122924805e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.4090774953365326e-01" rms="8.3271055221557617e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.8844838961958885e-02" rms="8.8715715408325195e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="2.5497969985008240e-01" cType="1" res="4.1842237114906311e-01" rms="7.8762984275817871e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0621811263263226e-02" rms="7.8501167297363281e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.1141433715820312e-01" rms="6.8537173271179199e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="9" Cut="6.2785482406616211e-01" cType="1" res="8.2458657026290894e-01" rms="8.6227617263793945e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="4" Cut="5.6418805122375488e+00" cType="1" res="6.4471960067749023e-01" rms="8.6131114959716797e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.6255704760551453e-02" rms="8.2039480209350586e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3122019171714783e-01" rms="8.7019214630126953e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="0" Cut="3.6137763977050781e+01" cType="1" res="8.7151441574096680e+00" rms="4.2389831542968750e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.2264605760574341e-01" rms="4.3639245033264160e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.0500161647796631e+00" rms="3.2684524059295654e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="79">
+      <Node pos="s" depth="0" NCoef="0" IVar="10" Cut="4.4215714931488037e-01" cType="1" res="7.5473271310329437e-02" rms="8.4464950561523438e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="9" Cut="7.8853130340576172e-01" cType="1" res="3.6136351525783539e-02" rms="8.4389772415161133e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="3.1805899739265442e-01" cType="1" res="-1.0688990354537964e-01" rms="8.5351190567016602e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.7392501533031464e-02" rms="8.5469312667846680e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.7718255296349525e-02" rms="8.4991273880004883e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="2.1996413171291351e-01" cType="1" res="8.7799489498138428e-01" rms="7.7962627410888672e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.5021278560161591e-02" rms="7.7142195701599121e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.2302763462066650e+00" rms="4.3605041503906250e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="11" Cut="9.3330167233943939e-02" cType="1" res="3.1187202930450439e+00" rms="8.4724864959716797e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.8051913976669312e-02" rms="8.5778741836547852e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          <Node pos="r" depth="2" NCoef="0" IVar="4" Cut="3.9552640914916992e+00" cType="1" res="3.9469382762908936e+00" rms="8.2225914001464844e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.5666168928146362e-01" rms="7.8530511856079102e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.9618381261825562e-01" rms="8.0450334548950195e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="80">
+      <Node pos="s" depth="0" NCoef="0" IVar="6" Cut="1.1570749664306641e+02" cType="1" res="2.5301498174667358e-01" rms="8.4859561920166016e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="15" Cut="6.1422526836395264e-01" cType="1" res="2.7346879243850708e-01" rms="8.4798631668090820e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="1.6173550415039062e+02" cType="1" res="-1.5553949400782585e-02" rms="8.3777847290039062e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.3700171858072281e-02" rms="8.2770633697509766e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.4961057901382446e-01" rms="1.0038668632507324e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="9.5807266235351562e-01" cType="1" res="8.6426162719726562e-01" rms="8.6548137664794922e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0198421031236649e-01" rms="8.6412611007690430e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7785600423812866e+00" rms="6.8638219833374023e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.7129884958267212e+00" rms="6.0262823104858398e+00" purity="1.0000000000000000e+00" nType="-99"/>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="81">
+      <Node pos="s" depth="0" NCoef="0" IVar="10" Cut="2.2817389667034149e-01" cType="1" res="1.9854427874088287e-01" rms="8.5289993286132812e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="4" Cut="9.8725814819335938e+00" cType="1" res="7.3270477354526520e-02" rms="8.5017633438110352e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="1.0854358971118927e-01" cType="1" res="-6.4120280742645264e-01" rms="7.8522820472717285e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.3696368038654327e-01" rms="7.7102942466735840e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.1121117323637009e-02" rms="8.2340316772460938e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="9.0156745910644531e-01" cType="1" res="4.6028658747673035e-01" rms="8.8094959259033203e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.5274837166070938e-02" rms="8.8218297958374023e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.8603523373603821e-01" rms="8.2322244644165039e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="11" Cut="2.3816490173339844e-01" cType="1" res="1.4207119941711426e+00" rms="8.6961097717285156e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="4.1840150952339172e-01" cType="1" res="3.6603870987892151e-01" rms="8.7468128204345703e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.0825364887714386e-02" rms="8.6656570434570312e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.7543034553527832e-01" rms="8.6622982025146484e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="4" Cut="3.2253906250000000e+01" cType="1" res="2.6230394840240479e+00" rms="8.4794120788574219e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.2647839188575745e-01" rms="8.4921779632568359e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.8032255172729492e+00" rms="5.9347243309020996e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="82">
+      <Node pos="s" depth="0" NCoef="0" IVar="0" Cut="4.6979153442382812e+02" cType="1" res="1.0737357288599014e-01" rms="8.5495719909667969e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="2" Cut="1.9422750473022461e+00" cType="1" res="8.8458813726902008e-02" rms="8.5436439514160156e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="2" Cut="1.3216991424560547e+00" cType="1" res="1.6462083160877228e-01" rms="8.5512371063232422e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.5576981008052826e-02" rms="8.5258646011352539e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.5867844223976135e-01" rms="8.6765632629394531e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="2" Cut="2.2688574790954590e+00" cType="1" res="-1.3363035917282104e+00" rms="8.2720689773559570e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.0615416169166565e-02" rms="8.0155696868896484e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.5215426683425903e-01" rms="8.5952692031860352e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.8791786193847656e+01" rms="5.9209322929382324e+00" purity="1.0000000000000000e+00" nType="-99"/>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="83">
+      <Node pos="s" depth="0" NCoef="0" IVar="15" Cut="6.1422526836395264e-01" cType="1" res="1.2923304922878742e-02" rms="8.4573354721069336e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="9" Cut="1.5385809540748596e-01" cType="1" res="-2.8117877244949341e-01" rms="8.3633594512939453e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="4" Cut="4.0237957000732422e+01" cType="1" res="3.0192079544067383e+00" rms="9.4370365142822266e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.2396784424781799e-01" rms="9.4596300125122070e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.8102929592132568e+00" rms="7.1298446655273438e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="15" Cut="5.8480575680732727e-02" cType="1" res="-3.4825587272644043e-01" rms="8.3265523910522461e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.2883351892232895e-02" rms="8.5241823196411133e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.1885612457990646e-01" rms="7.9597468376159668e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="14" Cut="3.1239640712738037e+00" cType="1" res="5.8866202831268311e-01" rms="8.6093072891235352e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="13" Cut="1.7398273468017578e+01" cType="1" res="7.5493472814559937e-01" rms="8.6282548904418945e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.9372956827282906e-02" rms="8.2115974426269531e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.8456794321537018e-01" rms="8.8511114120483398e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="2" Cut="3.7141162157058716e-01" cType="1" res="-2.2473058700561523e+00" rms="7.7482538223266602e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.5238585472106934e-02" rms="7.7631335258483887e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.3138508796691895e-01" rms="6.9148073196411133e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="84">
+      <Node pos="s" depth="0" NCoef="0" IVar="10" Cut="2.2817389667034149e-01" cType="1" res="1.6882193088531494e-01" rms="8.5160646438598633e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="9" Cut="7.3684883117675781e-01" cType="1" res="5.0541274249553680e-02" rms="8.4938774108886719e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="14" Cut="2.9827258586883545e+00" cType="1" res="-1.7856003344058990e-01" rms="8.5741558074951172e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.2477144151926041e-02" rms="8.5671033859252930e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.4146660566329956e-01" rms="8.4862327575683594e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="2.4966958165168762e-01" cType="1" res="7.7581000328063965e-01" rms="8.1924467086791992e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.1886836290359497e-02" rms="8.1725902557373047e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.5213402509689331e-01" rms="7.1278853416442871e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="6" Cut="1.1352831840515137e+01" cType="1" res="1.3632544279098511e+00" rms="8.6467618942260742e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="1.8493986129760742e-01" cType="1" res="1.0021530389785767e+00" rms="8.5075912475585938e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.0889256894588470e-02" rms="8.3778448104858398e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.4064218997955322e-01" rms="8.4900751113891602e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="3" Cut="1.1627707672119141e+02" cType="1" res="4.0471158027648926e+00" rms="9.1835880279541016e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.4015368819236755e-01" rms="9.2815561294555664e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.8284001350402832e+00" rms="6.1832518577575684e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="85">
+      <Node pos="s" depth="0" NCoef="0" IVar="6" Cut="9.8912132263183594e+01" cType="1" res="7.4728034436702728e-02" rms="8.4763069152832031e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="2" Cut="1.9418563842773438e+00" cType="1" res="9.0885460376739502e-02" rms="8.4691648483276367e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="2" Cut="9.0738451480865479e-01" cType="1" res="1.7088449001312256e-01" rms="8.4718866348266602e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.6553140953183174e-02" rms="8.4626302719116211e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2460706382989883e-01" rms="8.4556818008422852e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="3" Cut="1.3953143310546875e+02" cType="1" res="-1.4238992929458618e+00" rms="8.2727298736572266e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.7810556292533875e-01" rms="8.2097854614257812e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.8610472679138184e-01" rms="7.4342436790466309e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.8353302478790283e+00" rms="8.3289794921875000e+00" purity="1.0000000000000000e+00" nType="-99"/>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="86">
+      <Node pos="s" depth="0" NCoef="0" IVar="14" Cut="2.3489561080932617e+00" cType="1" res="7.2210833430290222e-02" rms="8.4963750839233398e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="0" Cut="5.4202404022216797e+01" cType="1" res="2.0872396230697632e-01" rms="8.5442304611206055e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="13" Cut="1.4739598274230957e+01" cType="1" res="-2.5149527192115784e-01" rms="7.9299998283386230e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.9428752660751343e-02" rms="7.8577909469604492e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4900742471218109e-01" rms="8.0502309799194336e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="6" Cut="8.8869056701660156e+01" cType="1" res="6.5117681026458740e-01" rms="9.0737438201904297e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0327299684286118e-01" rms="9.0549688339233398e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.3170151710510254e+00" rms="9.0732259750366211e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="10" Cut="6.4987175166606903e-02" cType="1" res="-9.2996269464492798e-01" rms="8.0660171508789062e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="1.2301241047680378e-02" cType="1" res="-4.5098051428794861e-01" rms="7.8291549682617188e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.7073951214551926e-02" rms="7.4942297935485840e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.8690441548824310e-01" rms="8.0600013732910156e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="3.0073386430740356e-01" cType="1" res="-2.3019371032714844e+00" rms="8.5618553161621094e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.1020357608795166e-01" rms="8.4408884048461914e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.6190492510795593e-01" rms="8.7506799697875977e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="87">
+      <Node pos="s" depth="0" NCoef="0" IVar="3" Cut="4.7260327148437500e+02" cType="1" res="1.3021343946456909e-01" rms="8.4278135299682617e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="11" Cut="4.6685636043548584e-01" cType="1" res="1.1238352209329605e-01" rms="8.4220695495605469e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="7.2803384065628052e-01" cType="1" res="-3.9433211088180542e-02" rms="8.3953561782836914e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.8211562931537628e-02" rms="8.5711431503295898e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.8647330403327942e-02" rms="7.8777432441711426e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="5.1786291599273682e-01" cType="1" res="1.0839236974716187e+00" rms="8.5272979736328125e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.7960802018642426e-02" rms="8.5094709396362305e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0061326026916504e+00" rms="7.0275573730468750e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.5188488006591797e+01" rms="6.4406208992004395e+00" purity="1.0000000000000000e+00" nType="-99"/>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="88">
+      <Node pos="s" depth="0" NCoef="0" IVar="6" Cut="-7.9208786010742188e+01" cType="1" res="6.1236694455146790e-02" rms="8.4938154220581055e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="11" Cut="4.4475357979536057e-02" cType="1" res="-1.9715651869773865e-01" rms="8.2606105804443359e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="1.8814571201801300e-02" cType="1" res="-4.3753333091735840e+00" rms="7.5122485160827637e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.0337611436843872e+00" rms="4.5982198715209961e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.4363930821418762e-01" rms="7.7879872322082520e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="3.8339772820472717e-01" cType="1" res="-1.3421167433261871e-01" rms="8.2552137374877930e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.3863588273525238e-02" rms="8.1580209732055664e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.9550119340419769e-02" rms="8.4561042785644531e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="2" Cut="1.2562249898910522e+00" cType="1" res="6.9987607002258301e-01" rms="9.0127134323120117e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="2.3305418014526367e+01" cType="1" res="4.5772176980972290e-01" rms="9.0110397338867188e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0988730192184448e-01" rms="9.0503139495849609e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.2205035239458084e-01" rms="8.7166347503662109e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="2" Cut="1.7443766593933105e+00" cType="1" res="2.0267987251281738e+00" rms="8.9057416915893555e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.4363816976547241e-01" rms="8.7616863250732422e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.9275643229484558e-02" rms="8.8580064773559570e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="89">
+      <Node pos="s" depth="0" NCoef="0" IVar="11" Cut="4.2325235903263092e-02" cType="1" res="1.1406180262565613e-01" rms="8.4440708160400391e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="8" Cut="2.9717389494180679e-02" cType="1" res="-2.6802225112915039e+00" rms="8.1671667098999023e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="1.6038995236158371e-02" cType="1" res="-4.2469968795776367e+00" rms="7.1761474609375000e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.9189502000808716e-01" rms="5.7163562774658203e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.5868319869041443e-01" rms="7.2503361701965332e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="2.9097659513354301e-02" cType="1" res="9.4656974077224731e-01" rms="9.1139764785766602e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.5738250315189362e-01" rms="8.0744104385375977e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0653893947601318e+00" rms="9.2010612487792969e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="9" Cut="7.7842074632644653e-01" cType="1" res="1.6329665482044220e-01" rms="8.4405794143676758e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="1.7680384218692780e-01" cType="1" res="-3.0684839002788067e-03" rms="8.5052690505981445e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.5533157885074615e-02" rms="8.4727010726928711e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2347587943077087e-01" rms="8.6099033355712891e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="2.1752683818340302e-01" cType="1" res="1.1266797780990601e+00" rms="7.9879350662231445e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.0904182493686676e-02" rms="7.9249124526977539e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2957569360733032e+00" rms="4.8265705108642578e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="90">
+      <Node pos="s" depth="0" NCoef="0" IVar="11" Cut="9.3371272087097168e-02" cType="1" res="1.3627333939075470e-01" rms="8.3959398269653320e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="13" Cut="3.8508457183837891e+01" cType="1" res="-9.0844857692718506e-01" rms="8.1217460632324219e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="8.1065238952636719e+01" cType="1" res="-1.3750324249267578e+00" rms="7.9148683547973633e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.2489918619394302e-01" rms="7.6657619476318359e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.7273906469345093e-01" rms="8.5546741485595703e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="2.1195438385009766e+01" cType="1" res="7.9046559333801270e-01" rms="8.6234436035156250e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.0962929129600525e-01" rms="8.3886260986328125e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.0995452404022217e-01" rms="8.4250717163085938e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="9" Cut="9.0917366743087769e-01" cType="1" res="2.2287616133689880e-01" rms="8.4124469757080078e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="13" Cut="9.1980995178222656e+01" cType="1" res="1.8902172148227692e-01" rms="8.4080448150634766e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.8816415518522263e-03" rms="8.4012117385864258e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.9486273527145386e-01" rms="8.4854145050048828e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4111669063568115e+00" rms="4.1983571052551270e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="91">
+      <Node pos="s" depth="0" NCoef="0" IVar="11" Cut="4.2017072439193726e-01" cType="1" res="8.6202844977378845e-02" rms="8.3625802993774414e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="13" Cut="1.5355253219604492e+01" cType="1" res="-9.6112646162509918e-02" rms="8.3135280609130859e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="4.2124265432357788e-01" cType="1" res="-4.0795761346817017e-01" rms="8.1887817382812500e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.6603686213493347e-02" rms="8.1563301086425781e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.7178941965103149e-01" rms="8.5127058029174805e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="14" Cut="5.7621306180953979e-01" cType="1" res="3.1127706170082092e-01" rms="8.4564228057861328e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.7403151988983154e-01" rms="7.8105731010437012e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2628766708076000e-02" rms="8.4487581253051758e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="9" Cut="5.5296051502227783e-01" cType="1" res="8.3797508478164673e-01" rms="8.5207681655883789e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="8.6370497941970825e-02" cType="1" res="4.4133001565933228e-01" rms="8.5230159759521484e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.8832951337099075e-02" rms="8.2944288253784180e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.4934732317924500e-01" rms="8.9248247146606445e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="5.8404791355133057e-01" cType="1" res="5.6981649398803711e+00" rms="6.8253035545349121e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.1285672187805176e-01" rms="6.8414316177368164e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.9332042932510376e+00" rms="4.6099338531494141e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="92">
+      <Node pos="s" depth="0" NCoef="0" IVar="6" Cut="5.9329704284667969e+01" cType="1" res="-6.6008843481540680e-02" rms="8.3876638412475586e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="11" Cut="4.6685636043548584e-02" cType="1" res="-3.5367231816053391e-02" rms="8.3763809204101562e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="1.9232322692871094e+01" cType="1" res="-2.3408627510070801e+00" rms="8.0767202377319336e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.2194029092788696e-01" rms="7.5815291404724121e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.7195459008216858e-02" rms="8.1556425094604492e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="5.8035051822662354e-01" cType="1" res="1.3320827856659889e-02" rms="8.3757534027099609e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.5907222181558609e-02" rms="8.3605442047119141e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7787648737430573e-01" rms="8.5343475341796875e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="11" Cut="3.0263718962669373e-01" cType="1" res="-5.7230081558227539e+00" rms="8.5498180389404297e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.6774705648422241e+00" rms="6.8817763328552246e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.4353797435760498e-01" rms="9.5546588897705078e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="93">
+      <Node pos="s" depth="0" NCoef="0" IVar="9" Cut="7.1770584583282471e-01" cType="1" res="8.9480914175510406e-02" rms="8.4021301269531250e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="2" Cut="2.1708104610443115e+00" cType="1" res="-1.5240091085433960e-01" rms="8.5692129135131836e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="12" Cut="1.1761904716491699e+01" cType="1" res="-8.3310134708881378e-02" rms="8.5743322372436523e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.7641980946063995e-02" rms="8.3602819442749023e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.1579799056053162e-02" rms="8.6540155410766602e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="2" Cut="2.1940333843231201e+00" cType="1" res="-2.4583053588867188e+00" rms="8.0638437271118164e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.6556428670883179e-01" rms="7.0102248191833496e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.5909851789474487e-01" rms="7.9526791572570801e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="11" Cut="2.8087827563285828e-01" cType="1" res="7.9873073101043701e-01" rms="7.8489842414855957e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="8" Cut="9.9678710103034973e-03" cType="1" res="5.7071924209594727e-01" rms="7.8255920410156250e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.8547240421175957e-02" rms="7.7896857261657715e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.7055267095565796e-01" rms="7.3101491928100586e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="7.2575628757476807e-01" cType="1" res="6.8077840805053711e+00" rms="5.8129768371582031e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.1175431609153748e-01" rms="5.8591814041137695e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.9529151916503906e+00" rms="4.3004188537597656e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="94">
+      <Node pos="s" depth="0" NCoef="0" IVar="8" Cut="3.9147228002548218e-02" cType="1" res="1.0558862984180450e-01" rms="8.3722400665283203e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="11" Cut="1.2870796024799347e-01" cType="1" res="-4.2948398739099503e-02" rms="8.3187398910522461e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="13" Cut="3.1226251602172852e+01" cType="1" res="-9.4760233163833618e-01" rms="7.9429116249084473e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.0471468567848206e-01" rms="7.7038593292236328e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.0629167333245277e-02" rms="8.3273983001708984e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="8.7851738929748535e-01" cType="1" res="1.0093757510185242e-01" rms="8.3679513931274414e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.2935352325439453e-03" rms="8.3618583679199219e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2688579559326172e+00" rms="4.0263285636901855e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="9" Cut="6.7279070615768433e-01" cType="1" res="8.7277561426162720e-01" rms="8.6025590896606445e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="13" Cut="3.9570491790771484e+01" cType="1" res="4.5532748103141785e-01" rms="8.6105670928955078e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.9334442690014839e-02" rms="8.5903072357177734e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.5497342348098755e-01" rms="8.2859745025634766e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="2.2194561362266541e-01" cType="1" res="3.8090980052947998e+00" rms="7.9490041732788086e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.1960144042968750e-01" rms="8.0237073898315430e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.5385719537734985e+00" rms="4.0657129287719727e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="95">
+      <Node pos="s" depth="0" NCoef="0" IVar="11" Cut="8.8950715959072113e-02" cType="1" res="1.5630699694156647e-01" rms="8.3264694213867188e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="8" Cut="2.7403059601783752e-01" cType="1" res="-1.1806471347808838e+00" rms="7.9847326278686523e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="3.7690681219100952e-01" cType="1" res="-1.6500296592712402e+00" rms="7.7029933929443359e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.6261925697326660e-01" rms="6.9041209220886230e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.8896390497684479e-01" rms="7.6730113029479980e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="5.8104586601257324e-01" cType="1" res="1.6093268394470215e+00" rms="8.9963150024414062e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.7179353162646294e-02" rms="8.9888372421264648e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3233772516250610e+00" rms="5.8493118286132812e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="9" Cut="7.5192350149154663e-01" cType="1" res="2.5977090001106262e-01" rms="8.3434066772460938e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="13" Cut="6.1199497222900391e+01" cType="1" res="5.2152503281831741e-02" rms="8.4358949661254883e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.8515598028898239e-02" rms="8.4020481109619141e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.9183584451675415e-01" rms="9.6236467361450195e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="2.5087797641754150e-01" cType="1" res="1.2818528413772583e+00" rms="7.7920351028442383e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1433275043964386e-01" rms="7.7714862823486328e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1921182870864868e+00" rms="5.2552313804626465e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="96">
+      <Node pos="s" depth="0" NCoef="0" IVar="9" Cut="9.0064978599548340e-01" cType="1" res="1.4445331692695618e-01" rms="8.3883848190307617e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="6" Cut="8.8869056701660156e+01" cType="1" res="8.0809384584426880e-02" rms="8.3799943923950195e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="1.8045596778392792e-01" cType="1" res="9.8610289394855499e-02" rms="8.3735990524291992e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.6498858630657196e-02" rms="8.2378683090209961e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.9833603873848915e-02" rms="8.4104509353637695e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.1771110296249390e+00" rms="8.2647037506103516e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="11" Cut="7.9905211925506592e-02" cType="1" res="2.2615189552307129e+00" rms="8.3921909332275391e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="9.3909192085266113e-01" cType="1" res="-4.3936419486999512e-01" rms="8.4777908325195312e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.8693627715110779e-01" rms="7.7939167022705078e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.3830232024192810e-01" rms="8.4476356506347656e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="9.2196589708328247e-01" cType="1" res="6.0732493400573730e+00" rms="6.6004972457885742e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.9668318033218384e-01" rms="6.7787437438964844e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.8469918966293335e+00" rms="4.8254766464233398e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="97">
+      <Node pos="s" depth="0" NCoef="0" IVar="9" Cut="7.3228639364242554e-01" cType="1" res="2.2104749083518982e-01" rms="8.3372421264648438e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="11" Cut="2.3342818021774292e-01" cType="1" res="2.0707124844193459e-02" rms="8.4785556793212891e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="3.4547008574008942e-02" cType="1" res="-7.4703270196914673e-01" rms="8.4479808807373047e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.3434222042560577e-02" rms="8.5022792816162109e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.8596228957176208e-01" rms="8.3653564453125000e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="1.9483865797519684e-01" cType="1" res="3.0833148956298828e-01" rms="8.4720859527587891e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4718627789989114e-03" rms="8.4246215820312500e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.5781065225601196e-01" rms="8.7028942108154297e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="11" Cut="2.7611517906188965e-01" cType="1" res="9.1065275669097900e-01" rms="7.7920680046081543e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="2.6273027062416077e-01" cType="1" res="7.6683896780014038e-01" rms="7.7577824592590332e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.7563453912734985e-02" rms="7.7578949928283691e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.3464637994766235e-01" rms="5.6827731132507324e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7189667224884033e+00" rms="4.6541376113891602e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="98">
+      <Node pos="s" depth="0" NCoef="0" IVar="5" Cut="-9.3783714294433594e+01" cType="1" res="2.0051969587802887e-01" rms="8.3415822982788086e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="11" Cut="2.3342818021774292e-01" cType="1" res="-2.6951741427183151e-02" rms="8.1004238128662109e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="7.8798139095306396e-01" cType="1" res="-6.0328030586242676e-01" rms="7.8379054069519043e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.0269505679607391e-01" rms="8.0876626968383789e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.9584981799125671e-03" rms="7.4637460708618164e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="7.8352445363998413e-01" cType="1" res="3.0639162659645081e-01" rms="8.2300472259521484e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4040193520486355e-02" rms="8.2149276733398438e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.2598392963409424e+00" rms="4.4831209182739258e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="5" Cut="1.5253947973251343e+00" cType="1" res="7.4584019184112549e-01" rms="8.8693981170654297e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="15" Cut="8.0149376392364502e-01" cType="1" res="1.0889992713928223e+00" rms="8.8389539718627930e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0081966221332550e-01" rms="8.8579597473144531e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.4763121604919434e-01" rms="8.7166090011596680e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="3.9401337504386902e-01" cType="1" res="-6.2287133932113647e-01" rms="8.8585262298583984e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.3175306618213654e-02" rms="8.9436273574829102e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.8255038857460022e-01" rms="8.2426395416259766e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="99">
+      <Node pos="s" depth="0" NCoef="0" IVar="11" Cut="5.7684713602066040e-01" cType="1" res="1.8056491017341614e-01" rms="8.3041744232177734e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="0" Cut="1.8599353027343750e+02" cType="1" res="8.9806765317916870e-02" rms="8.2862367630004883e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="1.7979174804687500e+02" cType="1" res="1.5274699032306671e-01" rms="8.2261333465576172e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.9429380558431149e-04" rms="8.2186632156372070e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1373178958892822e+00" rms="6.8969254493713379e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="2" Cut="1.0370875597000122e+00" cType="1" res="-1.9697371721267700e+00" rms="9.8369293212890625e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.1162900924682617e-01" rms="9.4575948715209961e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.9819684028625488e-01" rms="1.0536767005920410e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="9" Cut="4.2179065942764282e-01" cType="1" res="1.8499646186828613e+00" rms="8.4554624557495117e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="1.7382085800170898e+01" cType="1" res="1.3158817291259766e+00" rms="8.3829689025878906e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.9174088537693024e-02" rms="8.2037801742553711e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.3194699883460999e-01" rms="8.3232297897338867e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.6775037050247192e+00" rms="6.1951313018798828e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="100">
+      <Node pos="s" depth="0" NCoef="0" IVar="10" Cut="4.5953744649887085e-01" cType="1" res="9.7481861710548401e-02" rms="8.2599725723266602e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="11" Cut="1.4005690813064575e-01" cType="1" res="6.3557811081409454e-02" rms="8.2576150894165039e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="8.7215572595596313e-01" cType="1" res="-5.9871816635131836e-01" rms="7.9348974227905273e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.5383490920066833e-01" rms="8.0756607055664062e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.3331485241651535e-02" rms="7.3882479667663574e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="8.3511269092559814e-01" cType="1" res="2.0099459588527679e-01" rms="8.3164129257202148e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.9311219956725836e-05" rms="8.3256673812866211e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.7379362583160400e-01" rms="7.1790862083435059e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="4" Cut="5.9146437644958496e+00" cType="1" res="3.1024858951568604e+00" rms="7.9085106849670410e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="1.9794224202632904e-01" cType="1" res="1.1605195999145508e+00" rms="7.6905431747436523e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.4965514838695526e-01" rms="8.3276672363281250e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.9508444070816040e-01" rms="6.3968958854675293e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="1.2053488194942474e-01" cType="1" res="4.7855234146118164e+00" rms="7.7065076828002930e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.0335319042205811e-01" rms="7.8846826553344727e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1817173957824707e+00" rms="6.5727000236511230e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="101">
+      <Node pos="s" depth="0" NCoef="0" IVar="11" Cut="2.8011381626129150e-01" cType="1" res="5.0057131797075272e-02" rms="8.3309097290039062e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="6" Cut="4.6034154891967773e+00" cType="1" res="-2.5642949342727661e-01" rms="8.1496620178222656e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="7.1982890367507935e-01" cType="1" res="-5.9004563093185425e-01" rms="7.7467265129089355e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.1759547293186188e-01" rms="7.8304839134216309e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.1492975056171417e-02" rms="7.6277961730957031e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="2.3142856597900391e+01" cType="1" res="4.2733335494995117e-01" rms="8.8797044754028320e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.9620947539806366e-02" rms="8.8607177734375000e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.5147062540054321e-01" rms="8.6981658935546875e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="9" Cut="6.8341326713562012e-01" cType="1" res="3.9216998219490051e-01" rms="8.5156593322753906e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="4" Cut="1.2594459533691406e+01" cType="1" res="1.7353919148445129e-01" rms="8.5389995574951172e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.1245223730802536e-02" rms="8.0941610336303711e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3202205300331116e-01" rms="9.1901283264160156e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="3.0840650200843811e-01" cType="1" res="3.4885284900665283e+00" rms="7.5242643356323242e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.8677629530429840e-01" rms="7.5848331451416016e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1152104139328003e+00" rms="5.9856553077697754e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="102">
+      <Node pos="s" depth="0" NCoef="0" IVar="14" Cut="4.6979122161865234e+00" cType="1" res="4.5755714178085327e-02" rms="8.3446331024169922e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="12" Cut="3.3238094329833984e+01" cType="1" res="2.9222872108221054e-02" rms="8.3426818847656250e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="14" Cut="4.2142114639282227e+00" cType="1" res="1.1815211735665798e-02" rms="8.3328762054443359e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.2172029353678226e-02" rms="8.3292942047119141e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.0802066326141357e-01" rms="8.2145586013793945e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.0009288787841797e+00" rms="9.5506992340087891e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0719199180603027e+00" rms="6.4625821113586426e+00" purity="1.0000000000000000e+00" nType="-99"/>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="103">
+      <Node pos="s" depth="0" NCoef="0" IVar="9" Cut="8.7296718358993530e-01" cType="1" res="1.9923010468482971e-01" rms="8.2885503768920898e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="11" Cut="1.8674254417419434e-01" cType="1" res="1.1322207003831863e-01" rms="8.3079977035522461e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="6" Cut="-8.7175476074218750e+01" cType="1" res="-5.0739246606826782e-01" rms="8.1280698776245117e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.4310540258884430e-01" rms="7.5698819160461426e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.3791109919548035e-02" rms="8.7814121246337891e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="7.9066061973571777e-01" cType="1" res="3.2614344358444214e-01" rms="8.3582258224487305e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.8074754625558853e-02" rms="8.3718423843383789e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.6458494663238525e-01" rms="7.1002912521362305e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="11" Cut="1.2831240892410278e-01" cType="1" res="1.9333759546279907e+00" rms="7.6834959983825684e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="7.3116697371006012e-02" cType="1" res="1.1126335859298706e+00" rms="7.6105065345764160e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.2908783555030823e-02" rms="7.9012084007263184e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.3170489072799683e-01" rms="7.2579002380371094e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="1.6501209139823914e-01" cType="1" res="8.1969366073608398e+00" rms="4.8148016929626465e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.9901467561721802e-01" rms="5.3019280433654785e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.6057391166687012e+00" rms="2.3835484981536865e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="104">
+      <Node pos="s" depth="0" NCoef="0" IVar="2" Cut="1.9385929107666016e+00" cType="1" res="1.6584834456443787e-01" rms="8.3177795410156250e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="0" Cut="4.0740103149414062e+02" cType="1" res="2.4024252593517303e-01" rms="8.3107156753540039e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="4.2017513275146484e+01" cType="1" res="2.2430387139320374e-01" rms="8.3031492233276367e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.9791909754276276e-02" rms="7.5677471160888672e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.4751893728971481e-02" rms="8.5601396560668945e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.4495453834533691e+00" rms="8.8577136993408203e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="0" Cut="4.2860569000244141e+01" cType="1" res="-1.1939198970794678e+00" rms="8.3295936584472656e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="4.9326937645673752e-02" cType="1" res="6.4908725023269653e-01" rms="8.1068944931030273e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.3652743399143219e-01" rms="7.5936079025268555e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.0909648537635803e-01" rms="8.3538894653320312e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="5.1137620210647583e-01" cType="1" res="-2.0002355575561523e+00" rms="8.2974300384521484e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.6790367364883423e-01" rms="8.0157270431518555e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.8225228786468506e-01" rms="8.3947963714599609e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="105">
+      <Node pos="s" depth="0" NCoef="0" IVar="10" Cut="1.5317913889884949e-01" cType="1" res="7.7886775135993958e-02" rms="8.3435773849487305e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="1" Cut="3.6898365020751953e+01" cType="1" res="-9.7098387777805328e-02" rms="8.2886924743652344e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="6.5009671449661255e-01" cType="1" res="-1.1685977876186371e-01" rms="8.2839241027832031e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.0417931079864502e-02" rms="8.5670309066772461e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1928161606192589e-02" rms="7.9025511741638184e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2209457159042358e+00" rms="6.6036152839660645e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="0" Cut="8.9408821105957031e+01" cType="1" res="9.2307591438293457e-01" rms="8.5534896850585938e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="6.3938051462173462e-01" cType="1" res="1.3815230131149292e+00" rms="8.2680549621582031e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.5272955596446991e-01" rms="8.2400131225585938e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.1251112222671509e-01" rms="8.0982961654663086e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="13" Cut="2.0662660598754883e+01" cType="1" res="-9.3408966064453125e-01" rms="9.3974666595458984e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1725626140832901e-01" rms="9.3118505477905273e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.7830461263656616e-01" rms="8.9285917282104492e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="106">
+      <Node pos="s" depth="0" NCoef="0" IVar="6" Cut="-8.0863914489746094e+01" cType="1" res="8.0497160553932190e-02" rms="8.3204154968261719e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="3" Cut="3.5400396728515625e+02" cType="1" res="-1.1690498143434525e-01" rms="8.0864553451538086e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="9.5419251918792725e-01" cType="1" res="-9.0334869921207428e-02" rms="8.0749826431274414e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.3703405410051346e-02" rms="8.0587491989135742e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0908116102218628e+00" rms="9.1703500747680664e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.1979340314865112e+00" rms="8.5559864044189453e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="6" Cut="5.6132514953613281e+01" cType="1" res="5.6427419185638428e-01" rms="8.8491220474243164e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="14" Cut="2.2250592708587646e+00" cType="1" res="6.6852951049804688e-01" rms="8.8110933303833008e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4264616370201111e-01" rms="8.8370933532714844e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.1260313540697098e-01" rms="8.5694732666015625e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="1.7874826431274414e+01" cType="1" res="-3.9887273311614990e+00" rms="9.2969083786010742e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.7424988746643066e+00" rms="7.9003171920776367e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.7741292119026184e-01" rms="9.4538736343383789e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="107">
+      <Node pos="s" depth="0" NCoef="0" IVar="14" Cut="1.1744780540466309e+00" cType="1" res="-5.4310308769345284e-04" rms="8.3524541854858398e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="9" Cut="8.1488138437271118e-01" cType="1" res="2.6250782608985901e-01" rms="8.3846244812011719e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="6.1331623792648315e-01" cType="1" res="1.2470210343599319e-01" rms="8.4067373275756836e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.0747957974672318e-02" rms="8.3940315246582031e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.6475718617439270e-01" rms="8.4332399368286133e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="1.8981823325157166e-01" cType="1" res="1.8724030256271362e+00" rms="7.9467329978942871e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4568023383617401e-01" rms="7.9158887863159180e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2446619272232056e+00" rms="4.6465954780578613e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="13" Cut="6.4881332397460938e+01" cType="1" res="-4.4292831420898438e-01" rms="8.2792453765869141e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="12" Cut="1.8000000000000000e+01" cType="1" res="-5.7811272144317627e-01" rms="8.1799230575561523e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.2058495581150055e-02" rms="8.0650644302368164e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.2254070639610291e-01" rms="8.4308452606201172e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="14" Cut="3.1005272865295410e+00" cType="1" res="1.6922769546508789e+00" rms="9.4614458084106445e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.5700491666793823e-01" rms="9.0143337249755859e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.5563135147094727e-01" rms="9.1903209686279297e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="108">
+      <Node pos="s" depth="0" NCoef="0" IVar="10" Cut="2.1360604465007782e-01" cType="1" res="8.5724696516990662e-02" rms="8.2520551681518555e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="11" Cut="8.4109574556350708e-01" cType="1" res="-2.3814510554075241e-02" rms="8.2065229415893555e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="6" Cut="3.9670673370361328e+01" cType="1" res="-4.0797419846057892e-02" rms="8.2034502029418945e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.6319457218050957e-02" rms="8.1696586608886719e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.5877059698104858e-01" rms="9.5134096145629883e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7873858213424683e+00" rms="7.2070169448852539e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="2" Cut="-2.1665236949920654e+00" cType="1" res="1.0358076095581055e+00" rms="8.5784301757812500e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="7.3063293457031250e+01" cType="1" res="-2.3060426712036133e+00" rms="7.6700525283813477e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.3412397354841232e-02" rms="7.7467017173767090e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.1062541007995605e-01" rms="5.8873305320739746e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="0" Cut="2.2841702270507812e+02" cType="1" res="1.2566201686859131e+00" rms="8.5894145965576172e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3834822177886963e-01" rms="8.5689115524291992e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.2195577621459961e+00" rms="7.7892770767211914e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="109">
+      <Node pos="s" depth="0" NCoef="0" IVar="2" Cut="-1.9385629892349243e+00" cType="1" res="2.1363274753093719e-01" rms="8.3240175247192383e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="0" Cut="9.9347534179687500e+01" cType="1" res="-1.2863388061523438e+00" rms="8.1378755569458008e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="5.9359353780746460e-01" cType="1" res="-7.7554851770401001e-01" rms="7.9669179916381836e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.5397109091281891e-01" rms="7.8593988418579102e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.0751360654830933e-01" rms="7.5965642929077148e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="2.9144567251205444e-01" cType="1" res="-4.6916074752807617e+00" rms="8.4406585693359375e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.3981491327285767e-01" rms="9.6935377120971680e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.5537006855010986e-01" rms="7.1523628234863281e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="10" Cut="2.6806351542472839e-01" cType="1" res="2.9901835322380066e-01" rms="8.3263645172119141e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="1.8045596778392792e-01" cType="1" res="2.0441277325153351e-01" rms="8.2988920211791992e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.7402062714099884e-02" rms="8.1517219543457031e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.1572056710720062e-02" rms="8.3398313522338867e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="5.8016079664230347e-01" cType="1" res="1.7888520956039429e+00" rms="8.6116409301757812e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.0466636121273041e-01" rms="8.6164989471435547e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3289155960083008e+00" rms="6.0799055099487305e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="110">
+      <Node pos="s" depth="0" NCoef="0" IVar="13" Cut="3.5466827392578125e+01" cType="1" res="2.6727366447448730e-01" rms="8.3191471099853516e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="2" Cut="-2.1665160655975342e+00" cType="1" res="1.4901444315910339e-01" rms="8.2648458480834961e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="2.2328926086425781e+01" cType="1" res="-1.3660521507263184e+00" rms="8.7098903656005859e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.1545391678810120e-01" rms="8.5818643569946289e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.4112893640995026e-01" rms="8.4756336212158203e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="2" Cut="1.7468043565750122e+00" cType="1" res="1.9368430972099304e-01" rms="8.2471370697021484e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.3719901219010353e-02" rms="8.2373123168945312e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.3902573287487030e-01" rms="8.2984380722045898e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="8" Cut="3.4330122172832489e-02" cType="1" res="1.1753668785095215e+00" rms="8.6712884902954102e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="3.0756777524948120e-01" cType="1" res="8.0775362253189087e-01" rms="8.6822652816772461e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2098723649978638e+00" rms="5.1332173347473145e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.3007907271385193e-02" rms="8.6615304946899414e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="1.9817956924438477e+01" cType="1" res="3.7030088901519775e+00" rms="8.1586351394653320e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0077774524688721e+00" rms="7.6894373893737793e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.3944545090198517e-02" rms="7.7456374168395996e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="111">
+      <Node pos="s" depth="0" NCoef="0" IVar="9" Cut="9.7458386421203613e-01" cType="1" res="1.3456143438816071e-01" rms="8.2752037048339844e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="2" Cut="-1.9384540319442749e+00" cType="1" res="1.1451318114995956e-01" rms="8.2674760818481445e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="6.2753629684448242e-01" cType="1" res="-1.1834789514541626e+00" rms="8.3088636398315430e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.9910662770271301e-01" rms="8.3114080429077148e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.1135154366493225e-01" rms="7.5822358131408691e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="9.3371272087097168e-02" cType="1" res="1.8543425202369690e-01" rms="8.2593336105346680e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.2848462164402008e-01" rms="8.0503349304199219e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.0632293075323105e-02" rms="8.2711753845214844e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.8302494287490845e+00" rms="8.1317481994628906e+00" purity="1.0000000000000000e+00" nType="-99"/>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="112">
+      <Node pos="s" depth="0" NCoef="0" IVar="9" Cut="9.8826467990875244e-01" cType="1" res="7.2167277336120605e-02" rms="8.2449855804443359e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="5" Cut="-9.3795089721679688e+01" cType="1" res="5.6367691606283188e-02" rms="8.2396841049194336e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="8" Cut="3.4731071442365646e-02" cType="1" res="-1.6037312150001526e-01" rms="7.9906754493713379e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.7578079402446747e-02" rms="8.0146694183349609e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7625910043716431e-01" rms="7.4917860031127930e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="5.2380952835083008e+00" cType="1" res="6.0669434070587158e-01" rms="8.8165779113769531e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.5223617553710938e-01" rms="7.7448601722717285e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.5795605778694153e-02" rms="8.8155527114868164e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.9321175813674927e+00" rms="7.3850159645080566e+00" purity="1.0000000000000000e+00" nType="-99"/>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="113">
+      <Node pos="s" depth="0" NCoef="0" IVar="9" Cut="6.8099063634872437e-01" cType="1" res="9.6182309091091156e-02" rms="8.2591094970703125e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="12" Cut="1.4000000000000000e+01" cType="1" res="-9.5615923404693604e-02" rms="8.4900875091552734e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="16" Cut="5.0000000000000000e+00" cType="1" res="2.5618144869804382e-01" rms="8.2015256881713867e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.8107152581214905e-03" rms="8.3265953063964844e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.9182803034782410e-01" rms="7.4064393043518066e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="14" Cut="1.1744780540466309e+00" cType="1" res="-4.6411588788032532e-01" rms="8.6609554290771484e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.2883830368518829e-02" rms="8.6798076629638672e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.7359608411788940e-01" rms="8.5945262908935547e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="11" Cut="3.1208696961402893e-01" cType="1" res="5.1173532009124756e-01" rms="7.7187123298645020e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="14" Cut="3.3786523342132568e+00" cType="1" res="3.2795873284339905e-01" rms="7.6949181556701660e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.5030292123556137e-02" rms="7.6989312171936035e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.5083681941032410e-01" rms="7.3015394210815430e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="6.9096589088439941e-01" cType="1" res="6.5438179969787598e+00" rms="5.8413829803466797e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.8909693956375122e-01" rms="5.8593168258666992e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.9045466184616089e+00" rms="4.6887731552124023e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="114">
+      <Node pos="s" depth="0" NCoef="0" IVar="8" Cut="3.9147228002548218e-02" cType="1" res="7.8301243484020233e-02" rms="8.2829275131225586e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="11" Cut="1.8674254417419434e-01" cType="1" res="-5.0154894590377808e-02" rms="8.2693634033203125e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="1.7782164737582207e-02" cType="1" res="-5.5599820613861084e-01" rms="7.9577174186706543e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.3254262208938599e-01" rms="6.1208925247192383e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.0815635621547699e-02" rms="7.9436249732971191e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="7.9942208528518677e-01" cType="1" res="1.2676213681697845e-01" rms="8.3684101104736328e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.7581487074494362e-02" rms="8.3612728118896484e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.0982283353805542e-01" rms="7.1576046943664551e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="9" Cut="2.3827628791332245e-01" cType="1" res="7.5303238630294800e-01" rms="8.3213138580322266e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="1.8712483346462250e-01" cType="1" res="-1.5618878602981567e+00" rms="8.3812732696533203e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.3774049729108810e-02" rms="8.5708723068237305e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.5126166343688965e-01" rms="7.5007610321044922e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="8" Cut="4.3355315923690796e-01" cType="1" res="1.0895698070526123e+00" rms="8.2587137222290039e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.8178032338619232e-01" rms="8.1385507583618164e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.0473124980926514e-01" rms="8.8482618331909180e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="115">
+      <Node pos="s" depth="0" NCoef="0" IVar="14" Cut="3.3375890254974365e+00" cType="1" res="1.2699319422245026e-01" rms="8.2421293258666992e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="9" Cut="8.2281744480133057e-01" cType="1" res="1.7759898304939270e-01" rms="8.2567539215087891e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="4.5479175448417664e-01" cType="1" res="1.0375194996595383e-01" rms="8.3109416961669922e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.1211335435509682e-02" rms="8.2718009948730469e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.3574242889881134e-02" rms="8.4759807586669922e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="1.6497309505939484e-01" cType="1" res="9.8757493495941162e-01" rms="7.5901999473571777e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.5889076292514801e-02" rms="7.6584768295288086e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.9597867727279663e-01" rms="5.8479938507080078e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="9" Cut="5.0406295061111450e-01" cType="1" res="-1.3871690034866333e+00" rms="7.6383190155029297e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.3950464725494385e-01" rms="9.0510091781616211e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="8.5859256982803345e-01" cType="1" res="-1.8842909336090088e+00" rms="7.2928428649902344e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.2103478908538818e-01" rms="7.1444926261901855e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2655048072338104e-01" rms="7.2016797065734863e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="116">
+      <Node pos="s" depth="0" NCoef="0" IVar="13" Cut="6.7762718200683594e+01" cType="1" res="8.5104614496231079e-02" rms="8.2192554473876953e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="12" Cut="1.8857143402099609e+01" cType="1" res="3.5002049058675766e-02" rms="8.1925516128540039e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="12" Cut="1.7238094329833984e+01" cType="1" res="1.9993506371974945e-01" rms="8.0989522933959961e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.0538666285574436e-03" rms="8.0848112106323242e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.1061283349990845e-01" rms="8.1794795989990234e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="2" Cut="1.9267988204956055e+00" cType="1" res="-7.5133490562438965e-01" rms="8.5813694000244141e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.1892294138669968e-01" rms="8.5576248168945312e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.9224672317504883e-01" rms="8.1110267639160156e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="10" Cut="9.7480766475200653e-02" cType="1" res="2.9913399219512939e+00" rms="9.1861658096313477e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="16" Cut="6.0000000000000000e+00" cType="1" res="3.3949296474456787e+00" rms="8.1153736114501953e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0506228208541870e+00" rms="8.5004682540893555e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.3773992210626602e-02" rms="8.1585083007812500e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.8202112913131714e-01" rms="1.0163175582885742e+01" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="117">
+      <Node pos="s" depth="0" NCoef="0" IVar="10" Cut="1.9147393107414246e-01" cType="1" res="1.8519775569438934e-01" rms="8.2308626174926758e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="9" Cut="4.5978599786758423e-01" cType="1" res="7.7514827251434326e-02" rms="8.1915378570556641e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="2" Cut="1.9422750473022461e+00" cType="1" res="-6.0513287782669067e-01" rms="8.5421419143676758e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.8554657995700836e-02" rms="8.5776052474975586e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.5718140006065369e-01" rms="7.8596515655517578e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="5.1656413078308105e-01" cType="1" res="2.7722612023353577e-01" rms="8.0751895904541016e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1617877520620823e-02" rms="8.0487070083618164e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4627698659896851e+00" rms="7.0672941207885742e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="11" Cut="1.2544970214366913e-01" cType="1" res="9.4723558425903320e-01" rms="8.4649028778076172e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="4" Cut="3.0084171295166016e+01" cType="1" res="-8.6741089820861816e-01" rms="8.4117155075073242e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.7679920792579651e-01" rms="8.1628704071044922e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.9815038442611694e-01" rms="9.3603439331054688e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="2" Cut="-1.7149010896682739e+00" cType="1" res="1.3101648092269897e+00" rms="8.4287490844726562e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.7856580018997192e-01" rms="7.6578712463378906e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.4999223649501801e-01" rms="8.4627475738525391e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="118">
+      <Node pos="s" depth="0" NCoef="0" IVar="6" Cut="3.5192184448242188e+01" cType="1" res="6.4825832843780518e-02" rms="8.2500009536743164e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="14" Cut="1.4680975675582886e+00" cType="1" res="1.2379084527492523e-01" rms="8.2170839309692383e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="6.2495493888854980e-01" cType="1" res="3.0829906463623047e-01" rms="8.3121366500854492e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.0132891833782196e-02" rms="8.4562044143676758e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0393061488866806e-01" rms="8.0297679901123047e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="4" Cut="1.1578682899475098e+01" cType="1" res="-3.2590481638908386e-01" rms="7.9627871513366699e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.1835424005985260e-02" rms="7.3343644142150879e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.1235876381397247e-01" rms="8.2788572311401367e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="10" Cut="1.2997435033321381e-01" cType="1" res="-2.1266348361968994e+00" rms="9.1255578994750977e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="5.8240825310349464e-03" cType="1" res="-2.9401342868804932e+00" rms="8.8440895080566406e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3857108354568481e-01" rms="8.9362907409667969e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.2513389587402344e-01" rms="8.4080419540405273e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="14" Cut="7.6022356748580933e-01" cType="1" res="1.3985291719436646e+00" rms="9.4814987182617188e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3632748126983643e+00" rms="8.2872467041015625e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.9658427238464355e-01" rms="8.9147367477416992e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="119">
+      <Node pos="s" depth="0" NCoef="0" IVar="15" Cut="1.8426759243011475e+00" cType="1" res="5.0327599048614502e-02" rms="8.2311134338378906e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="8" Cut="5.9042817354202271e-01" cType="1" res="1.5741239488124847e-01" rms="8.1482696533203125e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="5.8215743303298950e-01" cType="1" res="1.4240726828575134e-01" rms="8.1450366973876953e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.6345638334751129e-02" rms="8.4602527618408203e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.4945979714393616e-02" rms="7.8230123519897461e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3895545005798340e+00" rms="7.0926027297973633e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="0" Cut="2.1962736511230469e+02" cType="1" res="-8.5122829675674438e-01" rms="8.8468065261840820e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="1.3628828430175781e+02" cType="1" res="-1.0404144525527954e+00" rms="8.7928838729858398e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.2821345031261444e-01" rms="8.7101364135742188e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.1862647533416748e-01" rms="9.0092697143554688e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3647285699844360e+00" rms="7.9263234138488770e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="120">
+      <Node pos="s" depth="0" NCoef="0" IVar="9" Cut="4.5490381121635437e-01" cType="1" res="8.5670128464698792e-02" rms="8.2390737533569336e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="10" Cut="7.6057970523834229e-02" cType="1" res="-4.3568950891494751e-01" rms="8.5714292526245117e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="1.1310790252685547e+02" cType="1" res="-1.1329442262649536e+00" rms="8.5637655258178711e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.4601390063762665e-01" rms="8.3722448348999023e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.2499672174453735e-01" rms="9.6229248046875000e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="2" Cut="1.9433004856109619e+00" cType="1" res="1.9613914191722870e-01" rms="8.5292816162109375e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.4735525548458099e-02" rms="8.5064735412597656e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.1027160882949829e-01" rms="7.6823968887329102e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="11" Cut="5.5603760480880737e-01" cType="1" res="2.8395134210586548e-01" rms="8.1002960205078125e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="2" Cut="-1.2581483125686646e+00" cType="1" res="2.5053024291992188e-01" rms="8.0898008346557617e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.5375186502933502e-01" rms="8.0704021453857422e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.5458457469940186e-03" rms="8.0802755355834961e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.2221701145172119e+00" rms="1.7249746322631836e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="121">
+      <Node pos="s" depth="0" NCoef="0" IVar="4" Cut="7.8124070167541504e+00" cType="1" res="1.3213849067687988e-01" rms="8.1926641464233398e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="13" Cut="1.8007858276367188e+01" cType="1" res="-6.3350677490234375e-01" rms="7.6659655570983887e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="1.1488436162471771e-01" cType="1" res="-7.8369289636611938e-01" rms="7.6289291381835938e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.6441211104393005e-01" rms="7.3548665046691895e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.9248477919027209e-04" rms="8.0570993423461914e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="4" Cut="7.3439359664916992e+00" cType="1" res="1.8232531547546387e+00" rms="7.8503980636596680e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.3064898252487183e-01" rms="7.5241541862487793e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.7083427309989929e-01" rms="7.7234110832214355e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="11" Cut="2.6492089033126831e-01" cType="1" res="3.8685783743858337e-01" rms="8.3449783325195312e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="7.9203331470489502e-01" cType="1" res="2.0804462954401970e-02" rms="8.1355800628662109e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.2188225090503693e-02" rms="8.2995128631591797e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.2208337485790253e-02" rms="7.6615333557128906e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="6.4773720502853394e-01" cType="1" res="8.5193181037902832e-01" rms="8.5811805725097656e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.3173405826091766e-02" rms="8.6200666427612305e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.3191385865211487e-01" rms="8.2622928619384766e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="122">
+      <Node pos="s" depth="0" NCoef="0" IVar="9" Cut="4.9967816472053528e-01" cType="1" res="7.0612899959087372e-02" rms="8.2453889846801758e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="13" Cut="4.3732501983642578e+01" cType="1" res="-4.4205445051193237e-01" rms="8.5422058105468750e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="5.2732616662979126e-01" cType="1" res="-5.4045325517654419e-01" rms="8.5051326751708984e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.2935592234134674e-01" rms="8.5540237426757812e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4992859214544296e-02" rms="8.3030738830566406e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="4" Cut="2.7383371353149414e+01" cType="1" res="1.9705114364624023e+00" rms="9.0778245925903320e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7083319425582886e+00" rms="6.3193550109863281e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0032895207405090e-01" rms="9.2427883148193359e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="11" Cut="5.0585860013961792e-01" cType="1" res="3.3453354239463806e-01" rms="8.0756626129150391e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="8" Cut="3.9920449256896973e-02" cType="1" res="2.9134517908096313e-01" rms="8.0662736892700195e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.2507409341633320e-03" rms="8.0260829925537109e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.7685576677322388e-01" rms="8.2534990310668945e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7802451848983765e+00" rms="3.0266797542572021e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="123">
+      <Node pos="s" depth="0" NCoef="0" IVar="3" Cut="1.3713597106933594e+02" cType="1" res="1.7491441220045090e-02" rms="8.2335090637207031e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="0" Cut="3.0289493560791016e+01" cType="1" res="1.0683894902467728e-01" rms="8.0913772583007812e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="13" Cut="2.3096691131591797e+01" cType="1" res="-1.2458142042160034e+00" rms="7.3520159721374512e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.8515646457672119e-01" rms="7.2483458518981934e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.6971900463104248e+00" rms="5.9525890350341797e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="3" Cut="1.2183389282226562e+02" cType="1" res="2.5356903672218323e-01" rms="8.1540775299072266e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0404717177152634e-02" rms="8.1256513595581055e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.0442049503326416e-01" rms="8.6306438446044922e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="12" Cut="3.0142856597900391e+01" cType="1" res="-1.0873582363128662e+00" rms="9.7551736831665039e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="2.6087394714355469e+01" cType="1" res="-1.3704516887664795e+00" rms="9.7332506179809570e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.6601222157478333e-01" rms="9.7716417312622070e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.6786735057830811e-01" rms="8.0703334808349609e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4106600284576416e+00" rms="8.4876022338867188e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="124">
+      <Node pos="s" depth="0" NCoef="0" IVar="9" Cut="9.0156531333923340e-01" cType="1" res="1.3365336693823338e-02" rms="8.1920900344848633e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="1" Cut="3.6583263397216797e+01" cType="1" res="-3.9442397654056549e-02" rms="8.2050781250000000e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="15" Cut="6.7564783096313477e+00" cType="1" res="-5.4892305284738541e-02" rms="8.2029876708984375e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.7123238891363144e-02" rms="8.1973609924316406e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1416423320770264e+00" rms="8.5143537521362305e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.4701108932495117e-01" rms="6.8512644767761230e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="11" Cut="1.1077492684125900e-01" cType="1" res="1.8107906579971313e+00" rms="7.5190424919128418e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="7.3814414441585541e-02" cType="1" res="1.0255079269409180e+00" rms="7.3633298873901367e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.1729095876216888e-02" rms="7.7243719100952148e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.6185064911842346e-01" rms="6.2586841583251953e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3405936956405640e+00" rms="5.7465815544128418e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="125">
+      <Node pos="s" depth="0" NCoef="0" IVar="1" Cut="3.6555709838867188e+01" cType="1" res="3.2587528228759766e-02" rms="8.2775125503540039e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="13" Cut="2.3644552230834961e+01" cType="1" res="1.5439419075846672e-02" rms="8.2718477249145508e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="5.8407951354980469e+01" cType="1" res="-1.3962934911251068e-01" rms="8.1682052612304688e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.4893923699855804e-02" rms="7.5623898506164551e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.2123509794473648e-02" rms="8.9237995147705078e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="7" Cut="-9.4268295288085938e+01" cType="1" res="5.2759552001953125e-01" rms="8.5854091644287109e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.2987734749913216e-02" rms="8.3283367156982422e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.6258561015129089e-01" rms="8.9905366897583008e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2162902355194092e+00" rms="8.0092792510986328e+00" purity="1.0000000000000000e+00" nType="-99"/>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="126">
+      <Node pos="s" depth="0" NCoef="0" IVar="11" Cut="7.5608104467391968e-01" cType="1" res="2.1595923602581024e-01" rms="8.2345342636108398e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="15" Cut="2.2327182292938232e+00" cType="1" res="1.9158667325973511e-01" rms="8.2276325225830078e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="7.7111512422561646e-01" cType="1" res="1.1108284443616867e-01" rms="8.1770925521850586e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.6290385276079178e-02" rms="8.2911434173583984e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.1465817987918854e-02" rms="7.5650782585144043e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="3.5938051342964172e-01" cType="1" res="1.1660465002059937e+00" rms="8.7579555511474609e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.8178306296467781e-02" rms="8.7243804931640625e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.2213621139526367e-01" rms="8.5205059051513672e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="9" Cut="2.2328789532184601e-01" cType="1" res="4.8862962722778320e+00" rms="8.2252426147460938e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.7120399475097656e-01" rms="8.6188335418701172e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.3720705509185791e+00" rms="6.0004143714904785e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="127">
+      <Node pos="s" depth="0" NCoef="0" IVar="14" Cut="2.5530629158020020e+00" cType="1" res="1.0170458257198334e-01" rms="8.1820240020751953e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="13" Cut="6.1421012878417969e+01" cType="1" res="1.9563628733158112e-01" rms="8.2150754928588867e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="13" Cut="2.0427564620971680e+01" cType="1" res="1.4623053371906281e-01" rms="8.1883964538574219e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.0571221821010113e-02" rms="8.0648565292358398e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.0675035715103149e-02" rms="8.6333417892456055e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="1.6187459945678711e+01" cType="1" res="3.5391254425048828e+00" rms="9.2606687545776367e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.0053781345486641e-02" rms="9.6338052749633789e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1245155334472656e+00" rms="8.7872333526611328e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="3" Cut="5.0160293579101562e+01" cType="1" res="-7.9699605703353882e-01" rms="7.8018131256103516e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="8" Cut="2.2581288591027260e-02" cType="1" res="9.5235186815261841e-01" rms="6.8959879875183105e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.3327397182583809e-02" rms="6.5901403427124023e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1717782020568848e+00" rms="7.1165442466735840e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="2" Cut="-1.9160627126693726e+00" cType="1" res="-1.3570734262466431e+00" rms="7.9898295402526855e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.7765560150146484e-01" rms="5.7283325195312500e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.7873620986938477e-01" rms="8.0180807113647461e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="128">
+      <Node pos="s" depth="0" NCoef="0" IVar="13" Cut="1.1616465759277344e+02" cType="1" res="1.4225068688392639e-01" rms="8.1811161041259766e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="11" Cut="2.8011381626129150e-01" cType="1" res="1.2588807940483093e-01" rms="8.1746368408203125e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="7.9203331470489502e-01" cType="1" res="-1.4176355302333832e-01" rms="7.9988036155700684e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.4610511064529419e-02" rms="8.1471366882324219e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.0157198905944824e-02" rms="7.5053253173828125e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="6.7837691307067871e-01" cType="1" res="4.2209291458129883e-01" rms="8.3549308776855469e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7766159027814865e-02" rms="8.3969240188598633e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.7982511520385742e-01" rms="7.4122624397277832e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.6146900653839111e+00" rms="7.9528274536132812e+00" purity="1.0000000000000000e+00" nType="-99"/>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="129">
+      <Node pos="s" depth="0" NCoef="0" IVar="11" Cut="3.5580286383628845e-01" cType="1" res="1.4260202646255493e-01" rms="8.1404256820678711e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="6" Cut="3.1508346557617188e+01" cType="1" res="-6.4729705452919006e-02" rms="8.0845050811767578e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="6.6254031658172607e-01" cType="1" res="-1.4039139449596405e-01" rms="8.0346689224243164e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.0863391757011414e-02" rms="8.3128948211669922e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.2730681858956814e-03" rms="7.7550811767578125e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="6" Cut="3.5335685729980469e+01" cType="1" res="2.2754962444305420e+00" rms="9.1952075958251953e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.6107864379882812e-01" rms="8.3062381744384766e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7198243737220764e-01" rms="9.3660717010498047e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="9" Cut="6.3959610462188721e-01" cType="1" res="6.2571537494659424e-01" rms="8.2490692138671875e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="5.8256858587265015e-01" cType="1" res="4.0214663743972778e-01" rms="8.2292604446411133e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2172576971352100e-02" rms="8.2977771759033203e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.5282457470893860e-01" rms="7.4966893196105957e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="6.5212166309356689e-01" cType="1" res="8.4660387039184570e+00" rms="4.0336995124816895e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.5115414857864380e-01" rms="4.2892069816589355e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.6128493547439575e+00" rms="3.2205116748809814e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="130">
+      <Node pos="s" depth="0" NCoef="0" IVar="15" Cut="4.2799210548400879e+00" cType="1" res="1.2434975057840347e-01" rms="8.1068582534790039e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="12" Cut="1.3238095283508301e+01" cType="1" res="1.6941615939140320e-01" rms="8.0952291488647461e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="2" Cut="-1.9380819797515869e+00" cType="1" res="4.3904682993888855e-01" rms="7.8786149024963379e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.7524670064449310e-01" rms="8.1875028610229492e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.8555997908115387e-02" rms="7.8396773338317871e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="1.2351094931364059e-01" cType="1" res="-6.9146983325481415e-02" rms="8.2748403549194336e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.5607412159442902e-01" rms="8.0335216522216797e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.7826087363064289e-03" rms="8.3022670745849609e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="0" Cut="4.7015560150146484e+01" cType="1" res="-2.4516961574554443e+00" rms="8.3509950637817383e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.2488014698028564e-01" rms="7.1738581657409668e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          <Node pos="r" depth="2" NCoef="0" IVar="14" Cut="2.1856169700622559e+00" cType="1" res="-3.3960123062133789e+00" rms="8.1404056549072266e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.7055510282516479e-01" rms="8.3964500427246094e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.4435411691665649e-01" rms="5.1567940711975098e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="131">
+      <Node pos="s" depth="0" NCoef="0" IVar="6" Cut="1.1570749664306641e+02" cType="1" res="6.2355902045965195e-02" rms="8.0974035263061523e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="6" Cut="7.1664756774902344e+01" cType="1" res="7.6488569378852844e-02" rms="8.0928211212158203e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="3.5601008683443069e-02" cType="1" res="6.1487458646297455e-02" rms="8.0894021987915039e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.4600238800048828e-02" rms="7.9744491577148438e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.9039712622761726e-02" rms="8.1851224899291992e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7745238542556763e+00" rms="6.2864470481872559e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.2993513345718384e+00" rms="7.6946101188659668e+00" purity="1.0000000000000000e+00" nType="-99"/>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="132">
+      <Node pos="s" depth="0" NCoef="0" IVar="2" Cut="1.2523312568664551e+00" cType="1" res="1.2625426054000854e-01" rms="8.1277875900268555e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="10" Cut="4.6290189027786255e-01" cType="1" res="-9.2205859255045652e-04" rms="8.1052331924438477e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="2" Cut="-2.0523238182067871e+00" cType="1" res="-3.9869580417871475e-02" rms="8.1033306121826172e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.0914408564567566e-01" rms="8.1225271224975586e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.6035966575145721e-02" rms="8.0959320068359375e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="9.6666669845581055e+00" cType="1" res="3.3854837417602539e+00" rms="7.5349855422973633e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.7745041847229004e-01" rms="6.3975329399108887e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.9502362012863159e-01" rms="8.1632308959960938e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="11" Cut="4.7701883316040039e-01" cType="1" res="7.4228960275650024e-01" rms="8.2083253860473633e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="15" Cut="4.2995772361755371e+00" cType="1" res="3.8177663087844849e-01" rms="8.1422138214111328e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.0056401193141937e-02" rms="8.1302366256713867e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.5318794250488281e-01" rms="7.2979030609130859e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="2" Cut="2.0143120288848877e+00" cType="1" res="3.0786612033843994e+00" rms="8.2511253356933594e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.2159984111785889e-01" rms="7.8648524284362793e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.7630370110273361e-02" rms="8.1751794815063477e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="133">
+      <Node pos="s" depth="0" NCoef="0" IVar="11" Cut="8.5805304348468781e-02" cType="1" res="9.8902933299541473e-02" rms="8.1690320968627930e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="5" Cut="-9.4062614440917969e+01" cType="1" res="-9.6947741508483887e-01" rms="7.9347200393676758e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="6.4265882968902588e-01" cType="1" res="-1.9188899993896484e+00" rms="7.0680594444274902e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2315101176500320e-01" rms="7.4683418273925781e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.8818652033805847e-01" rms="6.9064469337463379e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="13" Cut="3.2324234008789062e+01" cType="1" res="1.7362804710865021e-01" rms="8.7305660247802734e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.5094600617885590e-01" rms="8.7330226898193359e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.3345886468887329e-01" rms="8.1472816467285156e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="9" Cut="9.2366576194763184e-01" cType="1" res="1.7273500561714172e-01" rms="8.1798238754272461e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="7.0347082614898682e-01" cType="1" res="1.4864432811737061e-01" rms="8.1763095855712891e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.0553417503833771e-02" rms="8.3496818542480469e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.4958741664886475e-02" rms="7.6169457435607910e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.5924979448318481e+00" rms="4.3945956230163574e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="134">
+      <Node pos="s" depth="0" NCoef="0" IVar="10" Cut="1.5317913889884949e-01" cType="1" res="1.1330863833427429e-01" rms="8.1835403442382812e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="4" Cut="5.7238002777099609e+01" cType="1" res="-7.2361812926828861e-03" rms="8.0940828323364258e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="4" Cut="6.2826452255249023e+00" cType="1" res="-4.8277467489242554e-02" rms="8.0534601211547852e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.5578424632549286e-02" rms="7.2983531951904297e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.2672454193234444e-03" rms="8.1587123870849609e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="6.9641304016113281e-01" cType="1" res="2.1465392112731934e+00" rms="9.7576026916503906e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0788278579711914e+00" rms="9.2164335250854492e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.5399940609931946e-02" rms="9.7041397094726562e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="3" Cut="8.9851257324218750e+01" cType="1" res="6.9869548082351685e-01" rms="8.5807008743286133e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="7.9495956420898438e+01" cType="1" res="1.2664341926574707e+00" rms="8.2561979293823242e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.9285336136817932e-01" rms="8.1161355972290039e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.7477142214775085e-01" rms="9.2058105468750000e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="2.0360672473907471e-01" cType="1" res="-1.5296785831451416e+00" rms="9.4256229400634766e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.5856553614139557e-01" rms="9.2115974426269531e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.5334222316741943e-01" rms="9.2751531600952148e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="135">
+      <Node pos="s" depth="0" NCoef="0" IVar="4" Cut="5.9773784637451172e+01" cType="1" res="1.1543311411514878e-03" rms="8.1789484024047852e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="3" Cut="2.1809400939941406e+02" cType="1" res="3.9193417876958847e-02" rms="8.1449356079101562e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="8" Cut="3.3485744148492813e-02" cType="1" res="1.0916138067841530e-02" rms="8.1112165451049805e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.1135428696870804e-02" rms="8.0692033767700195e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.2328938394784927e-02" rms="8.3058776855468750e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="16" Cut="3.0000000000000000e+00" cType="1" res="1.9915158748626709e+00" rms="1.0083324432373047e+01" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3298317193984985e+00" rms="9.9223976135253906e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.9882833361625671e-01" rms="9.2530345916748047e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="10" Cut="1.3136779889464378e-02" cType="1" res="-2.3517360687255859e+00" rms="9.7782049179077148e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="2.1758092939853668e-01" cType="1" res="7.8564751148223877e-01" rms="9.8040647506713867e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.7665206193923950e-01" rms="9.0357894897460938e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4452838897705078e+00" rms="8.7704477310180664e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="1.8857143402099609e+01" cType="1" res="-4.4966821670532227e+00" rms="9.1617012023925781e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.5504082441329956e-01" rms="9.8252296447753906e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.6396073102951050e+00" rms="7.4439101219177246e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="136">
+      <Node pos="s" depth="0" NCoef="0" IVar="6" Cut="4.6393646240234375e+01" cType="1" res="8.7919756770133972e-02" rms="8.1638336181640625e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="15" Cut="4.2995772361755371e+00" cType="1" res="1.2375620007514954e-01" rms="8.1523990631103516e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="3.6228660583496094e+01" cType="1" res="1.6075341403484344e-01" rms="8.1471881866455078e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.3655480258166790e-03" rms="8.1420373916625977e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2633316516876221e+00" rms="8.2564468383789062e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="0" Cut="1.3313201904296875e+02" cType="1" res="-1.9697901010513306e+00" rms="8.1735849380493164e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.4502046704292297e-02" rms="8.0748062133789062e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.0084555149078369e+00" rms="6.1880626678466797e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="12" Cut="1.7857143402099609e+01" cType="1" res="-3.0693626403808594e+00" rms="8.5442285537719727e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="15" Cut="8.2206952571868896e-01" cType="1" res="-4.2066502571105957e+00" rms="8.1592521667480469e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.3733251094818115e-01" rms="8.7610750198364258e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.0334117412567139e+00" rms="5.0759553909301758e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="0" Cut="1.4058302307128906e+02" cType="1" res="-1.0384926795959473e+00" rms="8.8347396850585938e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.4153888225555420e-01" rms="8.5643949508666992e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.9414076209068298e-01" rms="8.8234148025512695e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="137">
+      <Node pos="s" depth="0" NCoef="0" IVar="11" Cut="3.2679945230484009e-01" cType="1" res="3.7713849544525146e-01" rms="8.1621170043945312e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="9" Cut="8.1100028753280640e-01" cType="1" res="1.6065192222595215e-01" rms="8.0485105514526367e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="6" Cut="-8.8323776245117188e+01" cType="1" res="-3.2906129956245422e-02" rms="8.1331882476806641e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.8955084532499313e-02" rms="7.8754682540893555e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.9133574366569519e-02" rms="8.5262289047241211e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="1.9671633839607239e-01" cType="1" res="1.1123704910278320e+00" rms="7.5466022491455078e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.8671281933784485e-02" rms="7.4864277839660645e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3789310455322266e+00" rms="4.7265982627868652e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="9" Cut="6.7950570583343506e-01" cType="1" res="7.4799972772598267e-01" rms="8.3400955200195312e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="5.8799332380294800e-01" cType="1" res="6.5926307439804077e-01" rms="8.3263168334960938e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.4759258627891541e-02" rms="8.3878746032714844e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.4979293346405029e-01" rms="7.9058594703674316e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7869213819503784e+00" rms="5.0590357780456543e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="138">
+      <Node pos="s" depth="0" NCoef="0" IVar="11" Cut="8.7616600096225739e-02" cType="1" res="-1.3230984332039952e-03" rms="8.1144475936889648e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="15" Cut="1.8539602756500244e+00" cType="1" res="-1.0631221532821655e+00" rms="7.7883887290954590e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="5" Cut="6.1451804637908936e-01" cType="1" res="-6.6792255640029907e-01" rms="7.7245883941650391e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.7141520977020264e-01" rms="7.3668942451477051e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.8654045462608337e-02" rms="8.2882671356201172e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="9.3809528350830078e+00" cType="1" res="-3.1916534900665283e+00" rms="7.7857446670532227e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.8436878323554993e-01" rms="6.8291063308715820e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.2682604789733887e-01" rms="7.4446907043457031e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="9" Cut="9.2537534236907959e-01" cType="1" res="7.9196669161319733e-02" rms="8.1329879760742188e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="12" Cut="3.2904762268066406e+01" cType="1" res="5.9981375932693481e-02" rms="8.1287851333618164e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.6709445044398308e-02" rms="8.1221265792846680e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1887779235839844e+00" rms="8.7584829330444336e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.9681459665298462e+00" rms="5.8726997375488281e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="139">
+      <Node pos="s" depth="0" NCoef="0" IVar="2" Cut="-1.2532981634140015e+00" cType="1" res="7.8003861010074615e-02" rms="8.1388721466064453e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="2" Cut="-1.5254302024841309e+00" cType="1" res="6.7231243848800659e-01" rms="8.2756280899047852e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="8" Cut="1.9097144901752472e-01" cType="1" res="7.6638981699943542e-02" rms="8.1818418502807617e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.7044893950223923e-02" rms="8.1523017883300781e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.5545324087142944e-01" rms="7.8700208663940430e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="0" Cut="1.4914396667480469e+02" cType="1" res="1.8366287946701050e+00" rms="8.3338928222656250e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.2261077165603638e-01" rms="8.2967185974121094e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.7653093338012695e+00" rms="6.1198563575744629e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="2" Cut="1.0083522796630859e+00" cType="1" res="-4.3258264660835266e-02" rms="8.1053342819213867e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="6" Cut="6.2030620574951172e+01" cType="1" res="-2.3551709949970245e-01" rms="8.0114336013793945e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.3101482093334198e-02" rms="8.0018911361694336e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.1263287067413330e+00" rms="8.4922246932983398e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="2" Cut="1.9357951879501343e+00" cType="1" res="5.0432306528091431e-01" rms="8.3427572250366211e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0550375282764435e-01" rms="8.3962125778198242e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.1575932055711746e-01" rms="8.0312004089355469e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="140">
+      <Node pos="s" depth="0" NCoef="0" IVar="9" Cut="9.7558444738388062e-01" cType="1" res="9.6278652548789978e-02" rms="8.1135759353637695e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="2" Cut="1.0298694372177124e+00" cType="1" res="8.2172110676765442e-02" rms="8.1091165542602539e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="8" Cut="2.3350335657596588e-01" cType="1" res="-5.7044122368097305e-02" rms="8.0536317825317383e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.2095383852720261e-02" rms="8.0150651931762695e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.1283493936061859e-01" rms="8.5594100952148438e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="2" Cut="2.3343062400817871e+00" cType="1" res="5.7568228244781494e-01" rms="8.2839927673339844e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.7905694246292114e-02" rms="8.2693386077880859e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.3803602457046509e-01" rms="7.6837339401245117e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4505252838134766e+00" rms="8.0056152343750000e+00" purity="1.0000000000000000e+00" nType="-99"/>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="141">
+      <Node pos="s" depth="0" NCoef="0" IVar="14" Cut="1.3906620740890503e+00" cType="1" res="1.1488523334264755e-01" rms="8.1045999526977539e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="2" Cut="-1.9433668851852417e+00" cType="1" res="3.2310521602630615e-01" rms="8.1671962738037109e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="1.3144964599609375e+02" cType="1" res="-1.2332475185394287e+00" rms="8.0555381774902344e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.1524895578622818e-01" rms="8.0238332748413086e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.7562503814697266e-01" rms="6.2404332160949707e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="13" Cut="1.2537838935852051e+01" cType="1" res="4.2074668407440186e-01" rms="8.1642656326293945e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.6485346481204033e-02" rms="7.9938468933105469e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.6731223464012146e-01" rms="8.7443294525146484e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="13" Cut="1.2378006935119629e+01" cType="1" res="-3.2073292136192322e-01" rms="7.9544420242309570e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="15" Cut="9.3107271194458008e-01" cType="1" res="-2.4168269634246826e+00" rms="6.5883073806762695e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.3681299388408661e-01" rms="6.4716668128967285e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.2897529602050781e-01" rms="6.6463522911071777e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="5.5624747276306152e-01" cType="1" res="-1.8810246884822845e-01" rms="8.0146532058715820e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.9308428317308426e-02" rms="7.9831728935241699e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.2670158147811890e-01" rms="8.8384361267089844e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="142">
+      <Node pos="s" depth="0" NCoef="0" IVar="14" Cut="3.2298147678375244e+00" cType="1" res="5.3075972944498062e-02" rms="8.1127271652221680e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="13" Cut="4.7289104461669922e+01" cType="1" res="9.9064320325851440e-02" rms="8.1297378540039062e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="7.2307074069976807e-01" cType="1" res="3.4973382949829102e-02" rms="8.0905513763427734e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.5329755395650864e-02" rms="8.2407684326171875e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.1609206944704056e-02" rms="7.5159239768981934e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="4.7179540991783142e-01" cType="1" res="1.3748112916946411e+00" rms="8.7769804000854492e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0697104930877686e+00" rms="8.4742450714111328e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0213195532560349e-01" rms="8.6983652114868164e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="2" Cut="8.0667465925216675e-01" cType="1" res="-1.0943217277526855e+00" rms="7.5864005088806152e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="2" Cut="3.4094354510307312e-01" cType="1" res="-1.8995637893676758e+00" rms="7.2496056556701660e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.3548068702220917e-01" rms="7.4004969596862793e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.7533800601959229e-01" rms="5.8589310646057129e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="1.0302434116601944e-01" cType="1" res="1.4388357400894165e+00" rms="8.0508089065551758e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.6149994134902954e-01" rms="6.8623681068420410e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.9520144462585449e-01" rms="8.0705232620239258e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="143">
+      <Node pos="s" depth="0" NCoef="0" IVar="0" Cut="1.3620036315917969e+02" cType="1" res="1.3871939480304718e-01" rms="8.1234321594238281e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="0" Cut="3.0295866012573242e+01" cType="1" res="2.1986612677574158e-01" rms="7.9752655029296875e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="6.5510578453540802e-02" cType="1" res="-9.6000081300735474e-01" rms="7.1033539772033691e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.2309315204620361e-01" rms="6.5882844924926758e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.8602914661169052e-02" rms="7.5914049148559570e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="14" Cut="1.4680975675582886e+00" cType="1" res="3.3970066905021667e-01" rms="8.0488767623901367e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.6143477559089661e-02" rms="8.1428041458129883e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.1116413176059723e-02" rms="7.8079466819763184e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="16" Cut="3.0000000000000000e+00" cType="1" res="-9.0938788652420044e-01" rms="9.4883356094360352e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="2.8178159713745117e+01" cType="1" res="2.8925165534019470e-01" rms="9.5821466445922852e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.4277729690074921e-02" rms="9.5394334793090820e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.1032631397247314e+00" rms="8.4098691940307617e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="1.0608230531215668e-01" cType="1" res="-2.6044335365295410e+00" rms="9.3061914443969727e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.1844568252563477e-01" rms="9.4277868270874023e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.3666901588439941e+00" rms="7.9012494087219238e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="144">
+      <Node pos="s" depth="0" NCoef="0" IVar="13" Cut="1.0929187774658203e+02" cType="1" res="4.1748732328414917e-02" rms="8.1049747467041016e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="14" Cut="4.6979122161865234e+00" cType="1" res="5.8893166482448578e-02" rms="8.1009597778320312e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="2.6628552246093750e+02" cType="1" res="4.5418474823236465e-02" rms="8.0985717773437500e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.3066231086850166e-03" rms="8.0767669677734375e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.6480445861816406e-01" rms="9.6421489715576172e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2322601079940796e+00" rms="6.3904385566711426e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.4358575344085693e-01" rms="7.0451064109802246e+00" purity="1.0000000000000000e+00" nType="-99"/>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="145">
+      <Node pos="s" depth="0" NCoef="0" IVar="9" Cut="8.4323948621749878e-01" cType="1" res="9.2229962348937988e-02" rms="8.1211795806884766e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="10" Cut="1.5317913889884949e-01" cType="1" res="2.4236962199211121e-02" rms="8.1486663818359375e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="5.3759723901748657e-01" cType="1" res="-1.0982219874858856e-01" rms="8.0883398056030273e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.0341580212116241e-01" rms="8.3559637069702148e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.8616713397204876e-03" rms="7.9175529479980469e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="2.3852735519409180e+01" cType="1" res="6.2095254659652710e-01" rms="8.3859834671020508e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.5330480188131332e-02" rms="8.4288644790649414e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.2064321637153625e-01" rms="7.9444527626037598e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="11" Cut="1.5358713269233704e-01" cType="1" res="1.0201457738876343e+00" rms="7.6763505935668945e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="2.9726440086960793e-02" cType="1" res="3.1721049547195435e-01" rms="7.5226397514343262e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.8317279219627380e-02" rms="7.4229674339294434e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.5380089282989502e-01" rms="7.3790979385375977e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="0" Cut="4.1603492736816406e+01" cType="1" res="7.8045368194580078e+00" rms="5.5387516021728516e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.4721695184707642e-01" rms="5.3324627876281738e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.8268126249313354e+00" rms="4.8703980445861816e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="146">
+      <Node pos="s" depth="0" NCoef="0" IVar="13" Cut="1.1822276115417480e+01" cType="1" res="2.7356240153312683e-01" rms="8.1402072906494141e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="14" Cut="1.2456426620483398e+00" cType="1" res="8.0339319538325071e-04" rms="8.1055765151977539e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="3.8294784724712372e-02" cType="1" res="6.5974436700344086e-02" rms="8.1505460739135742e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.8123538494110107e-02" rms="7.9801526069641113e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.3001277595758438e-02" rms="8.2750301361083984e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="4" Cut="1.6120815277099609e+01" cType="1" res="-1.2147283554077148e+00" rms="7.1069564819335938e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.1325337886810303e-01" rms="6.7827453613281250e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.1959038972854614e-01" rms="7.2794251441955566e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="0" Cut="5.7382629394531250e+01" cType="1" res="6.0746634006500244e-01" rms="8.1700143814086914e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="13" Cut="3.4618873596191406e+01" cType="1" res="1.0180318355560303e+00" rms="7.3704061508178711e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.8140619695186615e-02" rms="7.3364934921264648e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.3976168632507324e-01" rms="7.1952066421508789e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="16" Cut="3.0000000000000000e+00" cType="1" res="3.1956848502159119e-01" rms="8.5519866943359375e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.8039365112781525e-01" rms="8.8376016616821289e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.4420954547822475e-03" rms="8.5118980407714844e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="147">
+      <Node pos="s" depth="0" NCoef="0" IVar="6" Cut="5.9915260314941406e+01" cType="1" res="8.0962896347045898e-02" rms="8.1404848098754883e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="11" Cut="8.7065555155277252e-02" cType="1" res="1.0516906529664993e-01" rms="8.1322374343872070e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="5" Cut="-9.4062614440917969e+01" cType="1" res="-1.0289260149002075e+00" rms="7.8061046600341797e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.3380826413631439e-01" rms="7.0544371604919434e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.0633527338504791e-02" rms="8.6215667724609375e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="8.5135799646377563e-01" cType="1" res="1.8806523084640503e-01" rms="8.1493768692016602e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.4336385065689683e-03" rms="8.1674156188964844e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.9066205620765686e-01" rms="7.5544166564941406e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="16" Cut="1.0000000000000000e+00" cType="1" res="-4.4819207191467285e+00" rms="7.9942555427551270e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.4040828943252563e-01" rms="8.7956991195678711e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.3537852764129639e+00" rms="6.0530419349670410e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="148">
+      <Node pos="s" depth="0" NCoef="0" IVar="12" Cut="1.0000000000000000e+01" cType="1" res="4.5153889805078506e-02" rms="8.1797227859497070e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="13" Cut="5.4172168731689453e+01" cType="1" res="7.3725426197052002e-01" rms="8.1200962066650391e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="16" Cut="5.0000000000000000e+00" cType="1" res="6.5572077035903931e-01" rms="7.8651790618896484e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.1691949367523193e-02" rms="8.1044683456420898e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.0630847215652466e-01" rms="6.6046795845031738e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4181252717971802e+00" rms="6.2479271888732910e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="2" Cut="-1.9382021427154541e+00" cType="1" res="-8.0748364329338074e-02" rms="8.1842336654663086e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="1.1941710662841797e+02" cType="1" res="-1.3522913455963135e+00" rms="8.0671300888061523e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.3630549609661102e-01" rms="7.9767222404479980e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.6681611537933350e-01" rms="8.0588674545288086e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="7.1194672584533691e-01" cType="1" res="-2.2957975044846535e-02" rms="8.1848239898681641e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.5291468501091003e-02" rms="8.3403730392456055e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.7432519942522049e-02" rms="7.7671260833740234e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="149">
+      <Node pos="s" depth="0" NCoef="0" IVar="9" Cut="9.2537534236907959e-01" cType="1" res="2.0335841178894043e-01" rms="8.1220378875732422e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="11" Cut="2.2556996345520020e-01" cType="1" res="1.7194199562072754e-01" rms="8.1302328109741211e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="13" Cut="7.7443099975585938e+01" cType="1" res="-1.1696060746908188e-01" rms="8.0124435424804688e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.1832070797681808e-02" rms="7.9927477836608887e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.6590772867202759e-01" rms="8.2570552825927734e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="7.6824796199798584e-01" cType="1" res="3.4365388751029968e-01" rms="8.1946163177490234e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.3593498393893242e-02" rms="8.1986913681030273e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.8093663454055786e-01" rms="6.2899503707885742e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="11" Cut="8.4346368908882141e-02" cType="1" res="2.0305950641632080e+00" rms="7.4044098854064941e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="1.1142869567871094e+02" cType="1" res="9.5007157325744629e-01" rms="7.2305636405944824e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.5095396041870117e-02" rms="6.4957737922668457e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.8833363056182861e-01" rms="7.4131569862365723e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3526890277862549e+00" rms="6.0526013374328613e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="150">
+      <Node pos="s" depth="0" NCoef="0" IVar="11" Cut="1.8674254417419434e-01" cType="1" res="2.9402083158493042e-01" rms="8.0429553985595703e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="10" Cut="4.6281310915946960e-01" cType="1" res="-2.5460407137870789e-01" rms="7.8956708908081055e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="3.5568572580814362e-02" cType="1" res="-3.1827694177627563e-01" rms="7.8785252571105957e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.1654685735702515e-01" rms="7.6167426109313965e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.0377082079648972e-02" rms="7.8786797523498535e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="3.0335205793380737e-01" cType="1" res="2.5146760940551758e+00" rms="8.1399879455566406e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.3860347270965576e-01" rms="8.4495210647583008e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.2295033931732178e-01" rms="6.8561778068542480e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="9" Cut="5.9691637754440308e-01" cType="1" res="5.0811111927032471e-01" rms="8.0896167755126953e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="6" Cut="6.9908680915832520e+00" cType="1" res="2.0000956952571869e-01" rms="8.2421016693115234e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.0381170809268951e-02" rms="8.0638151168823242e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.0664878189563751e-01" rms="8.6380605697631836e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="3.5223031044006348e-01" cType="1" res="9.7062736749649048e-01" rms="7.8324341773986816e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.4056110084056854e-02" rms="7.7908349037170410e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.5921912193298340e-01" rms="7.4570050239562988e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="151">
+      <Node pos="s" depth="0" NCoef="0" IVar="9" Cut="4.7451567649841309e-01" cType="1" res="-1.1631407542154193e-03" rms="8.0380115509033203e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="6" Cut="-7.9208786010742188e+01" cType="1" res="-3.9882776141166687e-01" rms="8.3654336929321289e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="4.5113992691040039e-01" cType="1" res="-8.1344032287597656e-01" rms="8.0982141494750977e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.6178765296936035e-01" rms="7.8375587463378906e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.7965186387300491e-02" rms="8.1907567977905273e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="5" Cut="5.4963368177413940e-01" cType="1" res="8.5370123386383057e-02" rms="8.6419363021850586e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.8619033098220825e-01" rms="8.4361906051635742e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.6845008432865143e-02" rms="8.6183576583862305e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="11" Cut="5.1555585861206055e-01" cType="1" res="1.6915467381477356e-01" rms="7.8874950408935547e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="8" Cut="2.5226928293704987e-02" cType="1" res="1.3241408765316010e-01" rms="7.8818840980529785e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.7406595870852470e-02" rms="7.8362178802490234e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7207148671150208e-01" rms="8.1691608428955078e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="4.8679274320602417e-01" cType="1" res="5.5595231056213379e+00" rms="6.7779102325439453e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.8661751747131348e-01" rms="7.3339705467224121e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2676120996475220e+00" rms="4.2390794754028320e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="152">
+      <Node pos="s" depth="0" NCoef="0" IVar="6" Cut="-7.2161560058593750e+01" cType="1" res="1.0411178320646286e-01" rms="8.0692596435546875e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="10" Cut="2.6806351542472839e-01" cType="1" res="-9.1172814369201660e-02" rms="7.7971687316894531e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="4.5113991945981979e-02" cType="1" res="-2.0252376794815063e-01" rms="7.7591419219970703e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.3656882047653198e-01" rms="6.3244571685791016e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.4337989985942841e-02" rms="7.7598042488098145e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="2" Cut="1.9367995262145996e+00" cType="1" res="1.5769176483154297e+00" rms="8.1663551330566406e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.0294844508171082e-01" rms="8.0819215774536133e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.6800904273986816e-01" rms="8.3141298294067383e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="13" Cut="6.5598747253417969e+01" cType="1" res="5.7891756296157837e-01" rms="8.6770505905151367e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="6" Cut="2.5005729675292969e+01" cType="1" res="4.9157804250717163e-01" rms="8.6515455245971680e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.3095824122428894e-02" rms="8.5953741073608398e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.1001652479171753e-01" rms="8.8161935806274414e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="15" Cut="1.4699398279190063e+00" cType="1" res="5.2172713279724121e+00" rms="8.7660255432128906e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7968724966049194e+00" rms="6.9284715652465820e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.0479820966720581e-01" rms="1.0078910827636719e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="153">
+      <Node pos="s" depth="0" NCoef="0" IVar="11" Cut="7.4697017669677734e-01" cType="1" res="1.7844974994659424e-01" rms="8.1037254333496094e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="0" Cut="2.0729924011230469e+02" cType="1" res="1.5420892834663391e-01" rms="8.0951461791992188e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="3.3656978607177734e+01" cType="1" res="1.1106163263320923e-01" rms="8.0426588058471680e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.0110221058130264e-01" rms="6.9956746101379395e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.9503876566886902e-02" rms="8.1927928924560547e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="1.6086830139160156e+01" cType="1" res="1.9952216148376465e+00" rms="9.9097833633422852e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.1651740372180939e-01" rms="9.9384622573852539e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.4550067186355591e-01" rms="9.6321802139282227e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="9" Cut="2.2484624385833740e-01" cType="1" res="3.8912744522094727e+00" rms="8.5488243103027344e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="12" Cut="7.2380952835083008e+00" cType="1" res="9.8875731229782104e-01" rms="8.7716217041015625e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.9125203192234039e-02" rms="8.2121496200561523e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.2868710756301880e-01" rms="9.2194604873657227e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.9200170040130615e+00" rms="4.3303089141845703e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="154">
+      <Node pos="s" depth="0" NCoef="0" IVar="9" Cut="9.3397730588912964e-01" cType="1" res="4.3208226561546326e-02" rms="8.1224279403686523e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="4" Cut="4.4171806335449219e+01" cType="1" res="1.2402287684381008e-02" rms="8.1252622604370117e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="4" Cut="3.1649972915649414e+01" cType="1" res="7.5911201536655426e-02" rms="8.0578546524047852e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.4698527753353119e-02" rms="8.0008335113525391e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.9788693785667419e-01" rms="8.8984527587890625e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="0" Cut="2.9597784423828125e+02" cType="1" res="-1.4995392560958862e+00" rms="9.4661521911621094e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.2755389213562012e-01" rms="9.2693824768066406e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0306224822998047e+00" rms="9.9162673950195312e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="11" Cut="7.2261765599250793e-02" cType="1" res="2.4042303562164307e+00" rms="7.5363893508911133e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="4.3480329215526581e-02" cType="1" res="1.1892884969711304e+00" rms="7.6964945793151855e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.4931221306324005e-01" rms="7.5333709716796875e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.1440081596374512e-01" rms="7.2589831352233887e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.4054756164550781e-01" rms="4.8240828514099121e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="155">
+      <Node pos="s" depth="0" NCoef="0" IVar="10" Cut="1.7680384218692780e-01" cType="1" res="1.1025194078683853e-01" rms="8.1197271347045898e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="11" Cut="3.5498285293579102e-01" cType="1" res="9.1435789363458753e-04" rms="8.0785102844238281e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="13" Cut="7.0933654785156250e+01" cType="1" res="-1.8939714133739471e-01" rms="7.9851040840148926e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.2844144403934479e-02" rms="7.9409375190734863e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.0305696725845337e-01" rms="9.2537908554077148e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="6.4940387010574341e-01" cType="1" res="4.0645748376846313e-01" rms="8.2594223022460938e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.1742565557360649e-02" rms="8.2401714324951172e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2857837677001953e+00" rms="5.4180045127868652e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="9" Cut="6.3594406843185425e-01" cType="1" res="7.6471972465515137e-01" rms="8.3322505950927734e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="13" Cut="4.1587062835693359e+01" cType="1" res="5.4191470146179199e-01" rms="8.2650871276855469e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.8597763776779175e-02" rms="8.2247295379638672e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.5812643766403198e+00" rms="8.8732280731201172e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="1.4317397773265839e-01" cType="1" res="3.7616660594940186e+00" rms="8.6470403671264648e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7023682594299316e-01" rms="8.6372737884521484e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.0063991546630859e+00" rms="3.9190235137939453e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="156">
+      <Node pos="s" depth="0" NCoef="0" IVar="3" Cut="2.3003813171386719e+02" cType="1" res="9.1314770281314850e-02" rms="8.1324224472045898e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="0" Cut="1.5058380126953125e+02" cType="1" res="1.2265644222497940e-01" rms="8.0927743911743164e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="1.3413558959960938e+02" cType="1" res="6.2055401504039764e-02" rms="8.0152931213378906e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.8415334895253181e-03" rms="7.9721965789794922e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.7486079335212708e-01" rms="9.2487745285034180e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="3" Cut="1.8860128784179688e+02" cType="1" res="1.3353124856948853e+00" rms="9.4299383163452148e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.5573985576629639e-01" rms="8.9080619812011719e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.9976690411567688e-01" rms="1.0093841552734375e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="12" Cut="1.5142857551574707e+01" cType="1" res="-1.9483361244201660e+00" rms="1.0187076568603516e+01" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0430046319961548e+00" rms="1.0672027587890625e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          <Node pos="r" depth="2" NCoef="0" IVar="15" Cut="1.7855883836746216e+00" cType="1" res="-3.0296094417572021e+00" rms="9.7682647705078125e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.9866867065429688e-01" rms="9.4352750778198242e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.2069814205169678e-01" rms="1.0213172912597656e+01" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="157">
+      <Node pos="s" depth="0" NCoef="0" IVar="13" Cut="3.0806766510009766e+01" cType="1" res="9.4734668731689453e-02" rms="8.1022167205810547e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="10" Cut="7.1215674281120300e-02" cType="1" res="-1.0873123072087765e-02" rms="8.0389699935913086e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="8" Cut="4.3647065758705139e-01" cType="1" res="-2.3552368581295013e-01" rms="7.8906526565551758e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.8304354995489120e-02" rms="7.8769435882568359e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.4887307286262512e-01" rms="7.9988708496093750e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="6.6175311803817749e-01" cType="1" res="3.7990850210189819e-01" rms="8.2761316299438477e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.6750384122133255e-02" rms="8.3469247817993164e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.2176377475261688e-01" rms="7.7436089515686035e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="4" Cut="2.8684152603149414e+01" cType="1" res="7.1274363994598389e-01" rms="8.4363985061645508e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="4" Cut="2.3048177719116211e+01" cType="1" res="1.1592288017272949e+00" rms="8.1063613891601562e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.6694506704807281e-02" rms="8.0021038055419922e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.3676600456237793e-01" rms="8.2831182479858398e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="15" Cut="1.7566189765930176e+00" cType="1" res="-7.2285212576389313e-02" rms="8.9333944320678711e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.6643716394901276e-01" rms="8.8362770080566406e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.8851023316383362e-01" rms="8.9614639282226562e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="158">
+      <Node pos="s" depth="0" NCoef="0" IVar="11" Cut="6.0691326856613159e-01" cType="1" res="3.4765683114528656e-02" rms="8.1005907058715820e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="11" Cut="5.7748895138502121e-02" cType="1" res="-1.2697020545601845e-02" rms="8.0945930480957031e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="1.9143994897603989e-02" cType="1" res="-1.6698169708251953e+00" rms="7.4023566246032715e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.4088865518569946e-01" rms="7.4064073562622070e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.6428239643573761e-01" rms="7.2882056236267090e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="9.5463156700134277e-01" cType="1" res="4.3946474790573120e-02" rms="8.1112298965454102e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.1431601829826832e-02" rms="8.1080827713012695e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3609492778778076e+00" rms="7.3842835426330566e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="3" Cut="1.8721694946289062e+02" cType="1" res="1.2067919969558716e+00" rms="8.1601905822753906e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="8.3100497722625732e-02" cType="1" res="1.6871718168258667e+00" rms="7.9253134727478027e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2835186719894409e-01" rms="7.9455885887145996e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.0187219381332397e-01" rms="7.1132030487060547e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.2744517326354980e+00" rms="7.3205828666687012e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="159">
+      <Node pos="s" depth="0" NCoef="0" IVar="1" Cut="8.9439134597778320e+00" cType="1" res="1.3964497484266758e-03" rms="8.1642560958862305e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="14" Cut="1.8205150365829468e+00" cType="1" res="2.9676516056060791e+00" rms="7.3683333396911621e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="6.9590948522090912e-02" cType="1" res="4.2260189056396484e+00" rms="6.9837174415588379e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.4061455726623535e-01" rms="6.0219845771789551e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4372254610061646e+00" rms="7.8130030632019043e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.6325582982972264e-03" rms="7.2972831726074219e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="14" Cut="2.8037086129188538e-01" cType="1" res="-2.2391611710190773e-02" rms="8.1659708023071289e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="3.4465306997299194e-01" cType="1" res="2.8281474113464355e-01" rms="8.2364435195922852e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.3312300480902195e-03" rms="8.2187585830688477e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.1463303565979004e-01" rms="8.3177232742309570e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="3" Cut="1.7911253356933594e+02" cType="1" res="-2.5339400768280029e-01" rms="8.1045875549316406e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.4802664071321487e-02" rms="8.0352230072021484e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.2303301095962524e-01" rms="9.3230829238891602e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="160">
+      <Node pos="s" depth="0" NCoef="0" IVar="12" Cut="2.1523809432983398e+01" cType="1" res="9.3964852392673492e-02" rms="8.0580244064331055e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="9" Cut="9.3397730588912964e-01" cType="1" res="1.8148034811019897e-01" rms="7.9785790443420410e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="13" Cut="9.6803878784179688e+01" cType="1" res="1.5430596470832825e-01" rms="7.9717769622802734e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4614782994613051e-03" rms="7.9639401435852051e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.8566815853118896e-01" rms="8.5922031402587891e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="0" Cut="3.7292278289794922e+01" cType="1" res="2.7103283405303955e+00" rms="8.2030944824218750e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.6330777108669281e-01" rms="7.5615491867065430e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.7231190204620361e-01" rms="7.9354028701782227e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="15" Cut="2.0294997692108154e+00" cType="1" res="-9.6409517526626587e-01" rms="8.8950939178466797e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="8" Cut="1.6154552996158600e-01" cType="1" res="-6.6609108448028564e-01" rms="8.8530912399291992e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.4690124988555908e-01" rms="8.7925786972045898e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.2751765251159668e-01" rms="8.8696441650390625e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="0" Cut="1.4837348937988281e+02" cType="1" res="-4.6634564399719238e+00" rms="8.5784139633178711e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.0106109380722046e+00" rms="8.2403211593627930e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.9455876350402832e-01" rms="8.5219078063964844e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="161">
+      <Node pos="s" depth="0" NCoef="0" IVar="11" Cut="4.3808302283287048e-01" cType="1" res="1.0365466773509979e-01" rms="8.0791692733764648e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="13" Cut="1.0648426818847656e+02" cType="1" res="-1.1047138273715973e-01" rms="8.0223674774169922e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="6.1435347795486450e-01" cType="1" res="-9.2005342245101929e-02" rms="8.0135717391967773e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.6659992337226868e-02" rms="8.4048156738281250e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.4474013634026051e-03" rms="7.6634249687194824e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.0045942068099976e+00" rms="8.7839708328247070e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="9" Cut="5.7884150743484497e-01" cType="1" res="1.1873536109924316e+00" rms="8.2761945724487305e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="5.2326196432113647e-01" cType="1" res="9.9388402700424194e-01" rms="8.2345151901245117e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.9482961893081665e-02" rms="8.2484807968139648e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.2771356105804443e-01" rms="7.3380627632141113e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.7240762710571289e+00" rms="5.5488902330398560e-01" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="162">
+      <Node pos="s" depth="0" NCoef="0" IVar="8" Cut="3.9147228002548218e-02" cType="1" res="9.8113343119621277e-02" rms="8.0377140045166016e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="11" Cut="3.7675380706787109e-01" cType="1" res="-4.6864416450262070e-02" rms="7.9905190467834473e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="6.6956371068954468e-01" cType="1" res="-2.3889620602130890e-01" rms="7.8936715126037598e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.7638338804244995e-02" rms="8.3152074813842773e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.4395466148853302e-03" rms="7.5003547668457031e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="6.2498641014099121e-01" cType="1" res="4.4058889150619507e-01" rms="8.2110967636108398e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.4828996285796165e-03" rms="8.1825332641601562e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3176847696304321e+00" rms="4.9359517097473145e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="11" Cut="7.0197805762290955e-02" cType="1" res="8.5726326704025269e-01" rms="8.2389001846313477e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="3.2464307546615601e-01" cType="1" res="3.1997735500335693e+00" rms="8.2330036163330078e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.6805313304066658e-02" rms="9.6063537597656250e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.5940010547637939e-01" rms="7.6272134780883789e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="5.4532551765441895e-01" cType="1" res="6.7835313081741333e-01" rms="8.2119293212890625e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.5548292323946953e-02" rms="8.2398872375488281e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.9787678122520447e-01" rms="8.0960330963134766e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="163">
+      <Node pos="s" depth="0" NCoef="0" IVar="9" Cut="5.6585687398910522e-01" cType="1" res="4.6585090458393097e-02" rms="8.0778007507324219e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="6" Cut="8.3537483215332031e+00" cType="1" res="-2.6010391116142273e-01" rms="8.4113388061523438e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="4.2017072439193726e-01" cType="1" res="-5.8748465776443481e-01" rms="8.2292385101318359e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.9458244740962982e-01" rms="8.2434034347534180e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.8318951129913330e-02" rms="8.1635074615478516e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="5" Cut="1.2806988954544067e+00" cType="1" res="4.4498962163925171e-01" rms="8.7492284774780273e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7943368852138519e-01" rms="8.7997884750366211e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.7277738153934479e-02" rms="8.5983095169067383e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="11" Cut="4.4760429859161377e-01" cType="1" res="2.9389944672584534e-01" rms="7.7896628379821777e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="8" Cut="3.5707220435142517e-02" cType="1" res="2.5233465433120728e-01" rms="7.7758750915527344e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.9740186184644699e-03" rms="7.7379717826843262e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.3242911696434021e-01" rms="8.0553426742553711e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.8423407077789307e+00" rms="3.6269726753234863e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="164">
+      <Node pos="s" depth="0" NCoef="0" IVar="9" Cut="5.6706422567367554e-01" cType="1" res="7.2123751044273376e-02" rms="8.1096544265747070e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="11" Cut="7.1160572767257690e-01" cType="1" res="-1.9959947466850281e-01" rms="8.4225015640258789e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="3.3795993775129318e-02" cType="1" res="-2.5928956270217896e-01" rms="8.4268875122070312e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.8924278020858765e-01" rms="7.2198061943054199e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.2429981529712677e-02" rms="8.4257059097290039e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="2.6031053066253662e-01" cType="1" res="2.3551366329193115e+00" rms="7.8164210319519043e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.5541503727436066e-02" rms="7.7288317680358887e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.8145782947540283e-01" rms="6.3891420364379883e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="11" Cut="4.3603771924972534e-01" cType="1" res="3.0611169338226318e-01" rms="7.8226833343505859e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="3.1128528714179993e-01" cType="1" res="2.4118755757808685e-01" rms="7.8057503700256348e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.0663554146885872e-03" rms="7.7134251594543457e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.5444408357143402e-01" rms="8.1371641159057617e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.6272429227828979e+00" rms="4.0082192420959473e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="165">
+      <Node pos="s" depth="0" NCoef="0" IVar="6" Cut="-8.5006584167480469e+01" cType="1" res="1.4043623208999634e-01" rms="8.0443696975708008e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="9" Cut="6.1615192890167236e-01" cType="1" res="-6.7502193152904510e-02" rms="7.7925238609313965e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="6.3159590959548950e-01" cType="1" res="-4.7655820846557617e-01" rms="8.0223369598388672e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.4048097729682922e-02" rms="7.9946370124816895e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.8554033339023590e-01" rms="8.1238584518432617e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="3.7408569455146790e-01" cType="1" res="2.9886057972908020e-01" rms="7.5620241165161133e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.3177325539290905e-03" rms="7.5426363945007324e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.5556448698043823e-01" rms="6.6215343475341797e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="4" Cut="1.0966890335083008e+01" cType="1" res="6.5086835622787476e-01" rms="8.6102151870727539e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="3.8839710235595703e+01" cType="1" res="-2.3100470006465912e-01" rms="8.2607192993164062e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1283042281866074e-01" rms="8.1240205764770508e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.4060272276401520e-01" rms="8.2651252746582031e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="8" Cut="3.8917225599288940e-01" cType="1" res="1.0383515357971191e+00" rms="8.7312488555908203e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.1827070415019989e-01" rms="8.7236166000366211e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.7033439874649048e-01" rms="8.5137786865234375e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="166">
+      <Node pos="s" depth="0" NCoef="0" IVar="6" Cut="6.2030620574951172e+01" cType="1" res="1.2692955136299133e-01" rms="8.0625858306884766e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="9" Cut="9.8826467990875244e-01" cType="1" res="1.4375552535057068e-01" rms="8.0541048049926758e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="12" Cut="2.7142856597900391e+01" cType="1" res="1.3295777142047882e-01" rms="8.0490303039550781e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.5082805231213570e-03" rms="8.0271883010864258e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.9019123315811157e-01" rms="9.2231569290161133e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.9145097732543945e+00" rms="8.7662296295166016e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="0" Cut="1.4684599304199219e+02" cType="1" res="-3.2765357494354248e+00" rms="9.0007972717285156e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.4855788052082062e-01" rms="9.1324586868286133e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.1037099361419678e+00" rms="7.4857263565063477e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="167">
+      <Node pos="s" depth="0" NCoef="0" IVar="12" Cut="2.0000000000000000e+01" cType="1" res="9.3636140227317810e-02" rms="8.1192207336425781e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="10" Cut="3.8028985261917114e-02" cType="1" res="1.9069242477416992e-01" rms="8.0403480529785156e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="4" Cut="2.1662063598632812e+01" cType="1" res="-5.5763944983482361e-02" rms="7.8186349868774414e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.7831134647130966e-02" rms="7.5294637680053711e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3915446400642395e-01" rms="8.7033920288085938e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="8.1732022762298584e-01" cType="1" res="4.1475331783294678e-01" rms="8.2303342819213867e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.7750653922557831e-02" rms="8.2628164291381836e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.1049301624298096e-01" rms="6.5771875381469727e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="2" Cut="-7.8401881456375122e-01" cType="1" res="-4.7888618707656860e-01" rms="8.5473260879516602e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="4.7552978992462158e-01" cType="1" res="9.8051047325134277e-01" rms="8.8431539535522461e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4047064781188965e+00" rms="8.1683778762817383e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.0514288246631622e-02" rms="8.7486629486083984e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="7.2522389888763428e-01" cType="1" res="-8.4282553195953369e-01" rms="8.4326896667480469e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.2030791640281677e-01" rms="8.5837402343750000e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.7344496697187424e-02" rms="8.0181770324707031e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="168">
+      <Node pos="s" depth="0" NCoef="0" IVar="11" Cut="2.2556996345520020e-01" cType="1" res="1.7853811383247375e-01" rms="8.0823335647583008e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="14" Cut="4.5387783050537109e+00" cType="1" res="-1.1170891672372818e-01" rms="7.9304976463317871e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="6" Cut="7.4207415580749512e+00" cType="1" res="-1.4042487740516663e-01" rms="7.9225263595581055e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.9799771755933762e-02" rms="7.5710606575012207e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.2332995682954788e-02" rms="8.7524299621582031e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3879889249801636e+00" rms="7.9189105033874512e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="9" Cut="7.8503268957138062e-01" cType="1" res="3.6413010954856873e-01" rms="8.1725425720214844e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="8.5223458707332611e-02" cType="1" res="3.2240581512451172e-01" rms="8.1646938323974609e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.5008965581655502e-03" rms="8.0483179092407227e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4566990733146667e-01" rms="8.3891363143920898e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="0" Cut="4.3108016967773438e+01" cType="1" res="6.1545310020446777e+00" rms="7.1285519599914551e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.3492261171340942e-01" rms="7.8531827926635742e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.0246307849884033e+00" rms="2.8887758255004883e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="169">
+      <Node pos="s" depth="0" NCoef="0" IVar="15" Cut="4.2995772361755371e+00" cType="1" res="1.7761407792568207e-01" rms="8.0899343490600586e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="10" Cut="1.7800503969192505e-01" cType="1" res="2.1809901297092438e-01" rms="8.0827846527099609e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="8" Cut="5.8720844984054565e-01" cType="1" res="1.1905890703201294e-01" rms="8.0428447723388672e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.7420775303617120e-04" rms="8.0435371398925781e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.8123052120208740e-01" rms="6.5115208625793457e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="2" Cut="2.1708965301513672e+00" cType="1" res="8.2081884145736694e-01" rms="8.2962617874145508e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3751447200775146e-01" rms="8.2752952575683594e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.8777440190315247e-01" rms="7.6094512939453125e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="14" Cut="2.4934511184692383e+00" cType="1" res="-1.9967285394668579e+00" rms="8.1756343841552734e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="13" Cut="4.0142005920410156e+01" cType="1" res="-1.1755461692810059e+00" rms="8.3435611724853516e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.8605255484580994e-01" rms="7.7642769813537598e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.0095041990280151e-01" rms="9.3625602722167969e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.9006137847900391e-01" rms="4.3789873123168945e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="170">
+      <Node pos="s" depth="0" NCoef="0" IVar="14" Cut="2.5530629158020020e+00" cType="1" res="8.4253288805484772e-02" rms="8.0405616760253906e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="3" Cut="6.3857021331787109e+01" cType="1" res="1.9079397618770599e-01" rms="8.0869588851928711e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="13" Cut="3.2573154449462891e+01" cType="1" res="-5.2365135401487350e-02" rms="7.5099949836730957e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.9151832684874535e-02" rms="7.4821119308471680e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.3537007570266724e-01" rms="8.0046930313110352e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="15" Cut="1.8942184448242188e+00" cType="1" res="5.2619850635528564e-01" rms="8.8100833892822266e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1181046068668365e-01" rms="8.7787036895751953e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.4818552136421204e-01" rms="8.8828802108764648e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="9" Cut="6.5930092334747314e-01" cType="1" res="-9.3976920843124390e-01" rms="7.5033850669860840e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="16" Cut="3.0000000000000000e+00" cType="1" res="-1.8310698270797729e+00" rms="7.6122870445251465e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.4068446159362793e-01" rms="7.5553135871887207e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.8276255130767822e-01" rms="7.8850941658020020e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="2.2225091934204102e+01" cType="1" res="-3.6180841922760010e-01" rms="7.0973238945007324e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.8687514653429389e-04" rms="6.9097375869750977e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.5391840934753418e-01" rms="7.5623216629028320e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="171">
+      <Node pos="s" depth="0" NCoef="0" IVar="9" Cut="3.5250529646873474e-01" cType="1" res="7.6358555816113949e-03" rms="8.0539999008178711e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="11" Cut="5.0328183174133301e-01" cType="1" res="-6.7416155338287354e-01" rms="8.4181499481201172e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="7.4227867126464844e+01" cType="1" res="-1.2185103893280029e+00" rms="8.4480533599853516e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.8609226047992706e-02" rms="8.2770080566406250e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.1690155863761902e-01" rms="8.6654958724975586e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="4" Cut="1.4953822135925293e+01" cType="1" res="4.3306726217269897e-01" rms="8.2468576431274414e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.8935425207018852e-02" rms="8.1326971054077148e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.7294434309005737e-01" rms="8.4711952209472656e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="11" Cut="6.3041377067565918e-01" cType="1" res="1.1831926554441452e-01" rms="7.9878296852111816e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="9.1346077620983124e-02" cType="1" res="8.7226107716560364e-02" rms="7.9763107299804688e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.8742700815200806e-02" rms="7.8818049430847168e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.6237270832061768e-02" rms="8.2326526641845703e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.0607070922851562e+00" rms="6.8447031974792480e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="172">
+      <Node pos="s" depth="0" NCoef="0" IVar="0" Cut="8.0611045837402344e+01" cType="1" res="4.9268603324890137e-02" rms="8.0269889831542969e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="6" Cut="2.3818809509277344e+01" cType="1" res="2.4260048568248749e-01" rms="7.6299357414245605e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="4.5113992691040039e-01" cType="1" res="3.0532315373420715e-01" rms="7.6053242683410645e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.9172023795545101e-03" rms="7.5511512756347656e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4090795814990997e-01" rms="7.8639020919799805e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="4" Cut="2.5773809432983398e+01" cType="1" res="-1.8896731138229370e+00" rms="8.1413984298706055e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.2810319662094116e-01" rms="6.2683038711547852e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2289354577660561e-02" rms="8.5806455612182617e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="12" Cut="2.0285715103149414e+01" cType="1" res="-4.5930376648902893e-01" rms="8.9682130813598633e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="3.1824690103530884e-01" cType="1" res="-8.7544792890548706e-01" rms="8.9040203094482422e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.2692341208457947e-01" rms="8.9053316116333008e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.9600248336791992e-01" rms="8.2563791275024414e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="0" Cut="3.9832479858398438e+02" cType="1" res="9.7870564460754395e-01" rms="9.0402956008911133e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.5406407713890076e-02" rms="8.9920911788940430e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4493969917297363e+01" rms="8.3063468933105469e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="173">
+      <Node pos="s" depth="0" NCoef="0" IVar="4" Cut="1.0019368743896484e+02" cType="1" res="6.9873429834842682e-02" rms="8.0661935806274414e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="11" Cut="1.3009604811668396e-01" cType="1" res="8.5900321602821350e-02" rms="8.0605497360229492e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="0" Cut="1.4806381225585938e+02" cType="1" res="-6.0134166479110718e-01" rms="7.7675328254699707e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.0490891337394714e-01" rms="7.6574611663818359e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.1973321437835693e-01" rms="9.3651304244995117e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="8.8301253318786621e-01" cType="1" res="2.0719680190086365e-01" rms="8.1051197052001953e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.7913640998303890e-03" rms="8.1001348495483398e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.5875036716461182e+00" rms="4.3813705444335938e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.4053300619125366e+00" rms="7.8951754570007324e+00" purity="1.0000000000000000e+00" nType="-99"/>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="174">
+      <Node pos="s" depth="0" NCoef="0" IVar="11" Cut="1.7523320019245148e-01" cType="1" res="1.9128821790218353e-01" rms="8.0632686614990234e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="14" Cut="4.5048699378967285e+00" cType="1" res="-3.0511820316314697e-01" rms="7.8392405509948730e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="13" Cut="2.3419689178466797e+01" cType="1" res="-2.6282340288162231e-01" rms="7.8417549133300781e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.6833134293556213e-02" rms="7.6722011566162109e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.0171606242656708e-02" rms="8.1103086471557617e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.3475048542022705e-01" rms="5.3432583808898926e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="9" Cut="8.2908099889755249e-01" cType="1" res="3.6835649609565735e-01" rms="8.1343612670898438e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="9.8265871405601501e-02" cType="1" res="3.2093796133995056e-01" rms="8.1300201416015625e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.9706646241247654e-03" rms="8.0618143081665039e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2297008186578751e-01" rms="8.2819147109985352e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="1.3333333015441895e+01" cType="1" res="7.6670169830322266e+00" rms="4.8394317626953125e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.7653307914733887e-01" rms="5.4534354209899902e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.6268932819366455e+00" rms="2.6054332256317139e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="175">
+      <Node pos="s" depth="0" NCoef="0" IVar="8" Cut="3.4614819288253784e-01" cType="1" res="1.4366181194782257e-01" rms="8.0713777542114258e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="9" Cut="3.6488100886344910e-01" cType="1" res="7.7800005674362183e-02" rms="8.0463562011718750e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="2" Cut="-1.4819784164428711e+00" cType="1" res="-5.3976935148239136e-01" rms="8.3028755187988281e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.0362724661827087e-01" rms="7.6385698318481445e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.6898764073848724e-02" rms="8.3380594253540039e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="4.8426675796508789e-01" cType="1" res="1.6985689103603363e-01" rms="8.0033349990844727e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.7355704009532928e-03" rms="7.9923195838928223e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.8231691420078278e-01" rms="8.0396652221679688e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="9" Cut="4.4828477501869202e-01" cType="1" res="2.0008511543273926e+00" rms="8.5409421920776367e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="14" Cut="2.2014694213867188e+00" cType="1" res="1.3576087951660156e+00" rms="8.5591754913330078e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.1743190288543701e-01" rms="8.4667778015136719e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.1450443267822266e-01" rms="8.2343292236328125e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="2" Cut="3.1999967992305756e-02" cType="1" res="5.2847723960876465e+00" rms="7.6458764076232910e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4442816972732544e+00" rms="3.1452193260192871e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.2590690255165100e-01" rms="8.7739181518554688e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="176">
+      <Node pos="s" depth="0" NCoef="0" IVar="14" Cut="4.6979122161865234e+00" cType="1" res="6.1847973614931107e-02" rms="8.0616350173950195e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="6" Cut="7.9120918273925781e+01" cType="1" res="4.6475779265165329e-02" rms="8.0577106475830078e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="2.3342818021774292e-01" cType="1" res="6.2339406460523605e-02" rms="8.0515375137329102e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.8096477985382080e-02" rms="7.9907732009887695e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.9448645412921906e-02" rms="8.0881071090698242e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.9579808712005615e-01" rms="8.3632650375366211e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.6356513500213623e+00" rms="7.3613629341125488e+00" purity="1.0000000000000000e+00" nType="-99"/>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="177">
+      <Node pos="s" depth="0" NCoef="0" IVar="9" Cut="7.2138667106628418e-01" cType="1" res="1.2128105759620667e-01" rms="8.0946140289306641e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="2" Cut="-1.0249145030975342e+00" cType="1" res="-5.7074736803770065e-02" rms="8.2845726013183594e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="3.1385764479637146e-01" cType="1" res="6.4649248123168945e-01" rms="8.4690828323364258e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.6563676595687866e-02" rms="8.5564975738525391e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.4627032876014709e-01" rms="8.2597703933715820e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="2.4920706450939178e-01" cType="1" res="-2.6407524943351746e-01" rms="8.2180395126342773e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.2606280446052551e-02" rms="8.1633653640747070e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.5253737568855286e-01" rms="8.6407079696655273e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="11" Cut="2.8095421195030212e-01" cType="1" res="6.6624540090560913e-01" rms="7.4580030441284180e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="3.2755289226770401e-02" cType="1" res="5.6116580963134766e-01" rms="7.4582920074462891e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.2905083596706390e-02" rms="7.3410773277282715e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.9469901919364929e-01" rms="7.5770134925842285e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="2.9170060157775879e-01" cType="1" res="5.9013099670410156e+00" rms="5.2393789291381836e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.9686766266822815e-01" rms="4.7839245796203613e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3736146688461304e+00" rms="4.4861674308776855e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="178">
+      <Node pos="s" depth="0" NCoef="0" IVar="4" Cut="5.6773029327392578e+01" cType="1" res="9.7356475889682770e-02" rms="8.0541868209838867e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="4" Cut="5.7760066986083984e+00" cType="1" res="1.3206715881824493e-01" rms="8.0130310058593750e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="7.0028454065322876e-01" cType="1" res="-6.8723928928375244e-01" rms="7.3028407096862793e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.1795178055763245e-01" rms="7.2251834869384766e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.2773691415786743e-01" rms="7.7465362548828125e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="4" Cut="4.9280693054199219e+01" cType="1" res="2.5293794274330139e-01" rms="8.1055364608764648e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.6762869432568550e-02" rms="8.0873165130615234e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.4047256708145142e-01" rms="9.1291055679321289e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="15" Cut="2.4450705051422119e+00" cType="1" res="-1.7237142324447632e+00" rms="9.8072824478149414e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="12" Cut="1.3380952835083008e+01" cType="1" res="-2.5650794506072998e+00" rms="9.5581283569335938e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.6064467430114746e-02" rms="9.8316173553466797e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.4032169580459595e-01" rms="9.3143396377563477e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.8530230522155762e+00" rms="9.4514665603637695e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="179">
+      <Node pos="s" depth="0" NCoef="0" IVar="10" Cut="3.8294784724712372e-02" cType="1" res="2.2979941964149475e-01" rms="8.0686750411987305e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="13" Cut="1.5355253219604492e+01" cType="1" res="-1.5729662030935287e-02" rms="7.8691363334655762e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="6.3811962127685547e+01" cType="1" res="-3.6306610703468323e-01" rms="7.7925558090209961e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.0596083104610443e-01" rms="7.0697965621948242e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.7684402465820312e-02" rms="8.9381370544433594e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="2.8452737808227539e+01" cType="1" res="4.7089895606040955e-01" rms="7.9497065544128418e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.7357107996940613e-02" rms="7.9427289962768555e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.1757515668869019e-01" rms="7.5720338821411133e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="13" Cut="5.4645938873291016e+01" cType="1" res="4.6767890453338623e-01" rms="8.2504329681396484e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="8" Cut="4.9415254592895508e-01" cType="1" res="5.3907179832458496e-01" rms="8.2094306945800781e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.6213602423667908e-02" rms="8.2043695449829102e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.1315672397613525e-01" rms="7.8043260574340820e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="4" Cut="3.2823661804199219e+01" cType="1" res="-1.8388957977294922e+00" rms="9.1863574981689453e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.4440023303031921e-01" rms="9.7126483917236328e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.2848901748657227e-01" rms="8.2479152679443359e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="180">
+      <Node pos="s" depth="0" NCoef="0" IVar="11" Cut="1.7523320019245148e-01" cType="1" res="1.3295958936214447e-01" rms="8.0652475357055664e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="8" Cut="3.5025504231452942e-01" cType="1" res="-3.1363013386726379e-01" rms="7.9981160163879395e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="2" Cut="-7.8541666269302368e-01" cType="1" res="-4.5141646265983582e-01" rms="7.9084067344665527e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.8006940186023712e-01" rms="7.8442935943603516e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.8241448104381561e-02" rms="7.9078211784362793e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="5.7385873049497604e-02" cType="1" res="1.4895088672637939e+00" rms="8.8962965011596680e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.0133154988288879e-01" rms="8.1444568634033203e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.8501226902008057e-01" rms="8.3274917602539062e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="9" Cut="7.8055071830749512e-01" cType="1" res="2.8230038285255432e-01" rms="8.0820674896240234e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="2.4617069959640503e-01" cType="1" res="1.4171200990676880e-01" rms="8.1090841293334961e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.3009274899959564e-02" rms="7.9606804847717285e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.9941847547888756e-02" rms="8.1425476074218750e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="9.2486003413796425e-03" cType="1" res="2.7690627574920654e+00" rms="7.1448583602905273e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.5322990715503693e-01" rms="6.8683767318725586e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.3270838260650635e-01" rms="6.8175086975097656e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="181">
+      <Node pos="s" depth="0" NCoef="0" IVar="3" Cut="8.1280044555664062e+01" cType="1" res="9.7584269940853119e-02" rms="8.0230302810668945e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="0" Cut="4.3496761322021484e+01" cType="1" res="2.8578999638557434e-01" rms="7.6492085456848145e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="13" Cut="2.3096691131591797e+01" cType="1" res="-1.9629199802875519e-01" rms="7.2734885215759277e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.5849179625511169e-02" rms="7.2207117080688477e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.2599553465843201e-01" rms="7.6811308860778809e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="8" Cut="4.0289598703384399e-01" cType="1" res="6.2592685222625732e-01" rms="7.8858494758605957e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.7479846775531769e-02" rms="7.8658366203308105e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.6370599269866943e-01" rms="8.2369966506958008e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="2" Cut="1.7143527269363403e+00" cType="1" res="-3.9177694916725159e-01" rms="8.9034090042114258e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="2" Cut="-4.7544579952955246e-02" cType="1" res="-2.1758869290351868e-01" rms="8.9033985137939453e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.1653490364551544e-01" rms="8.9272918701171875e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.4244495928287506e-02" rms="8.8364849090576172e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="5.4848331212997437e-01" cType="1" res="-2.4384889602661133e+00" rms="8.6444950103759766e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.0797023773193359e-01" rms="8.2735996246337891e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.2655556201934814e-01" rms="8.8334836959838867e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="182">
+      <Node pos="s" depth="0" NCoef="0" IVar="10" Cut="1.7680384218692780e-01" cType="1" res="4.4914186000823975e-02" rms="8.0255088806152344e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="8" Cut="5.4806119203567505e-01" cType="1" res="-6.2748461961746216e-02" rms="7.9543566703796387e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="13" Cut="7.0933654785156250e+01" cType="1" res="-4.1178762912750244e-02" rms="7.9520030021667480e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.6817657276988029e-02" rms="7.9254155158996582e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.8355612754821777e-01" rms="9.1145248413085938e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="1.4334684610366821e-01" cType="1" res="-3.3268392086029053e+00" rms="7.6297254562377930e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.0743169784545898e-01" rms="6.4347114562988281e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.9856603443622589e-01" rms="7.8140139579772949e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="11" Cut="9.6667632460594177e-02" cType="1" res="6.8373185396194458e-01" rms="8.4070396423339844e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="2" Cut="1.2418620586395264e+00" cType="1" res="-1.1534923315048218e+00" rms="7.9904799461364746e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.5908648967742920e-02" rms="8.0540790557861328e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.1522880792617798e-01" rms="7.0642824172973633e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="6.8339806795120239e-01" cType="1" res="9.3636775016784668e-01" rms="8.4314651489257812e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1797042936086655e-01" rms="8.4228506088256836e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7645874023437500e+00" rms="6.5434813499450684e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="183">
+      <Node pos="s" depth="0" NCoef="0" IVar="10" Cut="5.7442182302474976e-01" cType="1" res="8.6117632687091827e-02" rms="8.0398607254028320e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="11" Cut="3.7348508834838867e-01" cType="1" res="6.3349567353725433e-02" rms="8.0330629348754883e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="7.7898508310317993e-01" cType="1" res="-1.5544089674949646e-01" rms="7.9625720977783203e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.0813277959823608e-02" rms="8.1079368591308594e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.5832481235265732e-02" rms="7.3768210411071777e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="6.1396229267120361e-01" cType="1" res="6.5072214603424072e-01" rms="8.1904582977294922e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.3464885801076889e-02" rms="8.2162256240844727e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.4449465274810791e-01" rms="6.1991338729858398e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="11" Cut="1.4064767956733704e-01" cType="1" res="5.4064311981201172e+00" rms="7.8577837944030762e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.1561236381530762e-01" rms="8.3155508041381836e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7396250963211060e+00" rms="6.7485928535461426e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="184">
+      <Node pos="s" depth="0" NCoef="0" IVar="4" Cut="8.2413902282714844e+01" cType="1" res="-1.6740668565034866e-02" rms="8.0426654815673828e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="4" Cut="4.2847375869750977e+00" cType="1" res="1.6248144209384918e-02" rms="8.0312843322753906e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="16" Cut="4.0000000000000000e+00" cType="1" res="-1.3597587347030640e+00" rms="7.0308752059936523e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.6617190241813660e-01" rms="7.3560314178466797e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.9274501800537109e-01" rms="6.3233470916748047e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="2.0947560667991638e-01" cType="1" res="9.7993895411491394e-02" rms="8.0536546707153320e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.6636368632316589e-02" rms="7.8479118347167969e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.5824291408061981e-02" rms="8.1540174484252930e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="9" Cut="7.4907171726226807e-01" cType="1" res="-7.0069322586059570e+00" rms="7.3724551200866699e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.1626380681991577e+00" rms="8.5480976104736328e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.3086373805999756e+00" rms="4.4693093299865723e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="185">
+      <Node pos="s" depth="0" NCoef="0" IVar="6" Cut="-7.2161560058593750e+01" cType="1" res="2.2070097923278809e-01" rms="8.0514411926269531e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="11" Cut="4.3532777577638626e-02" cType="1" res="8.0195050686597824e-03" rms="7.7671122550964355e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="7.9924452304840088e-01" cType="1" res="-3.5787441730499268e+00" rms="6.1217846870422363e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.4618748426437378e-01" rms="6.1203498840332031e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.1213188171386719e-01" rms="5.9784197807312012e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="9.5647197961807251e-01" cType="1" res="6.0232199728488922e-02" rms="7.7762899398803711e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.5827458426356316e-03" rms="7.7722520828247070e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.8047095537185669e-01" rms="5.6855444908142090e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="5" Cut="1.3616306781768799e+00" cType="1" res="7.3487442731857300e-01" rms="8.6790237426757812e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="4.3171611428260803e-01" cType="1" res="1.0939028263092041e+00" rms="8.6080074310302734e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.8017178773880005e-01" rms="8.6038665771484375e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.1286174058914185e-01" rms="7.9429216384887695e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="4" Cut="3.1001115798950195e+01" cType="1" res="-2.5613304972648621e-01" rms="8.7963762283325195e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.6499854624271393e-01" rms="8.6547603607177734e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.8424864411354065e-01" rms="9.0108823776245117e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="186">
+      <Node pos="s" depth="0" NCoef="0" IVar="2" Cut="5.7214468717575073e-01" cType="1" res="1.1609710007905960e-01" rms="8.0285024642944336e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="9" Cut="7.7157008647918701e-01" cType="1" res="-7.4337109923362732e-02" rms="7.9706029891967773e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="2" Cut="2.8882074356079102e-01" cType="1" res="-2.4642713367938995e-01" rms="8.0597600936889648e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.9309192672371864e-02" rms="8.0741529464721680e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.8319432437419891e-01" rms="7.8785991668701172e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="8" Cut="6.9899611175060272e-02" cType="1" res="7.5927865505218506e-01" rms="7.4678597450256348e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.2817849218845367e-02" rms="7.4443264007568359e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.6876171827316284e-01" rms="6.4336814880371094e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="11" Cut="2.2556996345520020e-01" cType="1" res="4.9807333946228027e-01" rms="8.1299600601196289e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="11" Cut="1.0739023238420486e-01" cType="1" res="-1.8294242024421692e-01" rms="7.9117507934570312e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.8673658370971680e-01" rms="7.8606142997741699e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2470402754843235e-02" rms="7.8961901664733887e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="0" Cut="2.0101977539062500e+02" cType="1" res="9.3038719892501831e-01" rms="8.2363262176513672e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.4647735357284546e-02" rms="8.1993312835693359e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.0210397243499756e+00" rms="8.6298742294311523e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="187">
+      <Node pos="s" depth="0" NCoef="0" IVar="10" Cut="3.8028985261917114e-01" cType="1" res="4.7367867082357407e-02" rms="7.9783363342285156e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="15" Cut="2.2745463848114014e+00" cType="1" res="4.1908212006092072e-03" rms="7.9648723602294922e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="2.2018721699714661e-01" cType="1" res="-6.2208596616983414e-02" rms="7.9086470603942871e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.1585986018180847e-01" rms="8.6560621261596680e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.9119028002023697e-02" rms="7.8750777244567871e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="8" Cut="1.5466700494289398e-01" cType="1" res="8.5832470655441284e-01" rms="8.6100845336914062e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.0788471251726151e-02" rms="8.5955371856689453e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.6356146335601807e-01" rms="8.2625255584716797e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="13" Cut="1.2256552696228027e+01" cType="1" res="1.7414418458938599e+00" rms="8.3146276473999023e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="2.1595256805419922e+01" cType="1" res="2.4938552379608154e+00" rms="8.1307878494262695e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.3991736769676208e-01" rms="7.8006563186645508e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.8171782493591309e-01" rms="8.5174856185913086e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="0" Cut="8.0327285766601562e+01" cType="1" res="-1.3272248506546021e+00" rms="8.3509159088134766e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.8283365964889526e-01" rms="8.6979808807373047e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.8547071218490601e-01" rms="6.9833407402038574e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="188">
+      <Node pos="s" depth="0" NCoef="0" IVar="14" Cut="2.6425757408142090e+00" cType="1" res="2.5092846155166626e-01" rms="7.9949097633361816e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="11" Cut="1.3142490386962891e-01" cType="1" res="3.4158405661582947e-01" rms="8.0237302780151367e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="16" Cut="5.0000000000000000e+00" cType="1" res="-3.8294348120689392e-01" rms="7.5687189102172852e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.8435706198215485e-02" rms="7.8069748878479004e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.2777917981147766e-01" rms="6.9570379257202148e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="5.4009479284286499e-01" cType="1" res="4.4650530815124512e-01" rms="8.0561771392822266e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.4176921471953392e-03" rms="8.3001031875610352e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.6265243589878082e-02" rms="7.8294620513916016e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="16" Cut="3.0000000000000000e+00" cType="1" res="-6.6358542442321777e-01" rms="7.5878224372863770e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="2" Cut="4.1645731776952744e-02" cType="1" res="1.8782864809036255e+00" rms="7.8080458641052246e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.5944234579801559e-02" rms="8.3005371093750000e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="5.4731988906860352e-01" rms="6.8421301841735840e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="1.4109306037425995e-01" cType="1" res="-8.9819794893264771e-01" rms="7.5736293792724609e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.2990815639495850e-02" rms="7.5018920898437500e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.8250532150268555e-01" rms="7.8722004890441895e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="189">
+      <Node pos="s" depth="0" NCoef="0" IVar="14" Cut="1.1744780540466309e+00" cType="1" res="1.9444233179092407e-01" rms="8.1010255813598633e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="13" Cut="7.2887501716613770e+00" cType="1" res="3.8681215047836304e-01" rms="8.1516971588134766e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="2.7638399600982666e-01" cType="1" res="1.5389472246170044e-01" rms="8.1150417327880859e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.5142671763896942e-01" rms="8.7517127990722656e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.0758556202054024e-02" rms="8.0225219726562500e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="6.9094017148017883e-02" cType="1" res="1.0718965530395508e+00" rms="8.2204055786132812e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.2641680240631104e-02" rms="8.1714210510253906e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.7427694201469421e-01" rms="8.2367591857910156e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="6" Cut="4.6737442016601562e+01" cType="1" res="-1.3287271559238434e-01" rms="8.0034532546997070e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="2.8706440329551697e-01" cType="1" res="-9.2157088220119476e-02" rms="7.9978752136230469e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.1904377937316895e-01" rms="8.9261083602905273e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.9417989552021027e-02" rms="7.9532790184020996e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.8729428052902222e-01" rms="7.5030074119567871e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="190">
+      <Node pos="s" depth="0" NCoef="0" IVar="11" Cut="3.1132748723030090e-01" cType="1" res="1.4695429801940918e-01" rms="8.0761489868164062e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="6" Cut="2.9005296707153320e+01" cType="1" res="-1.1448910832405090e-01" rms="7.9940266609191895e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="7.3316454887390137e-01" cType="1" res="-1.8618740141391754e-01" rms="7.9466767311096191e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-8.5345312952995300e-02" rms="8.2292852401733398e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.4233851581811905e-02" rms="7.4577727317810059e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="1.0784911364316940e-01" cType="1" res="1.4165998697280884e+00" rms="8.8073158264160156e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.5474323928356171e-01" rms="8.4263286590576172e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.9383795261383057e-01" rms="8.7122974395751953e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="9" Cut="6.8980699777603149e-01" cType="1" res="5.4572981595993042e-01" rms="8.1837549209594727e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="2.7834095060825348e-02" cType="1" res="4.5905059576034546e-01" rms="8.1775932312011719e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.0675507634878159e-02" rms="8.0069866180419922e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2850663065910339e-01" rms="8.2625532150268555e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="6.9765245914459229e-01" cType="1" res="7.6239547729492188e+00" rms="4.9487848281860352e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.6666644811630249e-01" rms="5.6169066429138184e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4614057540893555e+00" rms="3.0073955059051514e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="191">
+      <Node pos="s" depth="0" NCoef="0" IVar="9" Cut="5.1169747114181519e-01" cType="1" res="2.9707545414566994e-02" rms="7.9651880264282227e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="6" Cut="-7.2161560058593750e+01" cType="1" res="-2.7695319056510925e-01" rms="8.2344646453857422e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="1.1488436162471771e-01" cType="1" res="-7.1173459291458130e-01" rms="7.9405183792114258e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.8683606386184692e-01" rms="7.5935254096984863e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.6700558364391327e-02" rms="8.2420673370361328e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="2.5933504104614258e-01" cType="1" res="2.5481596589088440e-01" rms="8.5502996444702148e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.2772401869297028e-02" rms="8.4599676132202148e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4017510414123535e-01" rms="8.5755443572998047e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="11" Cut="4.5111134648323059e-01" cType="1" res="2.0672994852066040e-01" rms="7.8000316619873047e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="4.2422279715538025e-02" cType="1" res="1.1299034953117371e-01" rms="7.7715573310852051e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.0979612618684769e-02" rms="7.6111431121826172e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.8987123668193817e-02" rms="7.9717040061950684e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="3.9144610054790974e-03" cType="1" res="3.3241851329803467e+00" rms="8.0978584289550781e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.2147756665945053e-01" rms="7.9116754531860352e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.5360246896743774e+00" rms="5.9431600570678711e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="192">
+      <Node pos="s" depth="0" NCoef="0" IVar="14" Cut="3.8170537948608398e+00" cType="1" res="-1.5835215162951499e-04" rms="7.9802732467651367e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="15" Cut="2.2745463848114014e+00" cType="1" res="2.6347974315285683e-02" rms="7.9847245216369629e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="3.5601008683443069e-02" cType="1" res="-3.5674959421157837e-02" rms="7.9362277984619141e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.9644082784652710e-02" rms="7.7378873825073242e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.5786979608237743e-03" rms="8.1111335754394531e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="15" Cut="4.5768857002258301e+00" cType="1" res="8.8419526815414429e-01" rms="8.5817203521728516e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.5072002410888672e-01" rms="8.4962387084960938e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.1821540594100952e-01" rms="8.4563884735107422e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="1" Cut="2.1341672897338867e+01" cType="1" res="-1.7162730693817139e+00" rms="7.4895610809326172e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="14" Cut="4.6189122200012207e+00" cType="1" res="-1.4660742878913879e-01" rms="7.3631024360656738e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.7450752854347229e-01" rms="6.9352359771728516e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.0946100950241089e-01" rms="7.4509735107421875e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="2.0857143402099609e+01" cType="1" res="-4.4425344467163086e+00" rms="6.9024581909179688e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.5009602308273315e-01" rms="6.2677783966064453e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.0773781538009644e+00" rms="6.8255558013916016e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="193">
+      <Node pos="s" depth="0" NCoef="0" IVar="0" Cut="3.6296432495117188e+02" cType="1" res="1.4848001301288605e-01" rms="8.0000886917114258e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="6" Cut="7.1466773986816406e+01" cType="1" res="1.6726946830749512e-01" rms="7.9944510459899902e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="4.0740543603897095e-01" cType="1" res="1.4703729748725891e-01" rms="7.9875268936157227e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.6033145189285278e-02" rms="8.3391695022583008e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.3781500756740570e-02" rms="7.8921771049499512e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.9868464469909668e+00" rms="7.1017708778381348e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.8631750345230103e-01" rms="8.0566616058349609e+00" purity="1.0000000000000000e+00" nType="-99"/>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="194">
+      <Node pos="s" depth="0" NCoef="0" IVar="8" Cut="3.1133779883384705e-01" cType="1" res="-1.3717653229832649e-02" rms="7.9995555877685547e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="3" Cut="7.1211372375488281e+01" cType="1" res="-6.4750500023365021e-02" rms="7.9879112243652344e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="10" Cut="1.1488436162471771e-01" cType="1" res="1.0793938487768173e-01" rms="7.5061211585998535e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-3.3080324530601501e-02" rms="7.3793954849243164e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.1296354979276657e-01" rms="7.8368740081787109e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="1.9925358891487122e-01" cType="1" res="-3.6818993091583252e-01" rms="8.7623653411865234e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.4285882264375687e-02" rms="8.7511816024780273e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.7536877989768982e-01" rms="8.7526159286499023e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="8" Cut="3.5991755127906799e-01" cType="1" res="1.2368359565734863e+00" rms="8.1808948516845703e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="1" Cut="2.0709804534912109e+01" cType="1" res="3.7993834018707275e+00" rms="7.6212387084960938e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.1535512208938599e-01" rms="7.2621436119079590e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.6054348647594452e-01" rms="7.5944199562072754e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="1.4952381134033203e+01" cType="1" res="4.5338195562362671e-01" rms="8.1859283447265625e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.3220603615045547e-02" rms="7.9274568557739258e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.9518183469772339e-01" rms="8.4366350173950195e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="195">
+      <Node pos="s" depth="0" NCoef="0" IVar="6" Cut="-8.5751144409179688e+01" cType="1" res="3.2269753515720367e-02" rms="7.9393525123596191e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="0" Cut="3.6675549316406250e+02" cType="1" res="-1.2052299082279205e-01" rms="7.6690068244934082e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="8" Cut="1.3892428576946259e-01" cType="1" res="-9.7281083464622498e-02" rms="7.6566300392150879e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-2.9538176953792572e-02" rms="7.6591639518737793e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.1209453940391541e-01" rms="6.9904298782348633e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.3481146097183228e+00" rms="8.6349697113037109e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="2" Cut="5.7525020837783813e-01" cType="1" res="4.1880297660827637e-01" rms="8.5731954574584961e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="6" Cut="1.1417608261108398e+01" cType="1" res="7.7592426538467407e-01" rms="8.4853572845458984e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.0324465632438660e-01" rms="8.2371559143066406e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.2575704157352448e-02" rms="8.6856460571289062e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="12" Cut="2.3428571701049805e+01" cType="1" res="-2.7250197529792786e-01" rms="8.6991634368896484e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-9.6443958580493927e-02" rms="8.6788043975830078e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="8.1224793195724487e-01" rms="7.8852744102478027e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="196">
+      <Node pos="s" depth="0" NCoef="0" IVar="9" Cut="5.2891296148300171e-01" cType="1" res="1.1482238769531250e-01" rms="7.9599785804748535e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="14" Cut="1.3477735519409180e+00" cType="1" res="-3.0369246006011963e-01" rms="8.2629270553588867e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="6" Cut="6.2030620574951172e+01" cType="1" res="-5.3498786687850952e-01" rms="8.2442951202392578e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-1.0313013195991516e-01" rms="8.2374544143676758e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="6.3640505075454712e-01" rms="7.6696839332580566e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="4" Cut="3.9531993865966797e+01" cType="1" res="5.5765593051910400e-01" rms="8.2752761840820312e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.0953631997108459e-01" rms="8.1631755828857422e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.7291567325592041e-01" rms="8.8576488494873047e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="11" Cut="4.3692174553871155e-01" cType="1" res="3.9004248380661011e-01" rms="7.7419862747192383e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="8" Cut="1.5924172103404999e-01" cType="1" res="3.0588126182556152e-01" rms="7.7346897125244141e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4389595016837120e-02" rms="7.7038617134094238e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="4.5032259821891785e-01" rms="8.2204866409301758e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="9" Cut="5.7913839817047119e-01" cType="1" res="3.1985168457031250e+00" rms="7.4553923606872559e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.5850096344947815e-01" rms="7.3646183013916016e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="2.0844621658325195e+00" rms="2.8560707569122314e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="197">
+      <Node pos="s" depth="0" NCoef="0" IVar="11" Cut="2.3342818021774292e-01" cType="1" res="1.1639963835477829e-01" rms="8.0122175216674805e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="9" Cut="8.3004850149154663e-01" cType="1" res="-2.6317754387855530e-01" rms="7.7988495826721191e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="12" Cut="2.4666666030883789e+01" cType="1" res="-4.7270384430885315e-01" rms="7.9159107208251953e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.2018086910247803e-02" rms="7.9051718711853027e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.0857654809951782e-01" rms="7.9195380210876465e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="1.6261005401611328e-01" cType="1" res="5.3961163759231567e-01" rms="7.2774391174316406e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.5368331745266914e-03" rms="7.3731570243835449e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.8612350821495056e-01" rms="5.7465810775756836e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="9" Cut="7.3245954513549805e-01" cType="1" res="3.8378775119781494e-01" rms="8.1485643386840820e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="15" Cut="3.0711264610290527e+00" cType="1" res="2.7572041749954224e-01" rms="8.1929197311401367e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.4733062125742435e-02" rms="8.1925344467163086e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.7632885575294495e-01" rms="7.8744368553161621e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="10" Cut="1.9002055749297142e-02" cType="1" res="2.3757596015930176e+00" rms="6.9896435737609863e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7348450422286987e-01" rms="6.7987093925476074e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.3001918792724609e+00" rms="5.0370354652404785e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="198">
+      <Node pos="s" depth="0" NCoef="0" IVar="11" Cut="4.2017072439193726e-01" cType="1" res="1.2344063073396683e-01" rms="8.0035104751586914e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="6" Cut="4.1839004516601562e+01" cType="1" res="-2.1524634212255478e-03" rms="7.9505119323730469e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="9" Cut="6.2495493888854980e-01" cType="1" res="-3.5012789070606232e-02" rms="7.9153742790222168e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-6.0534648597240448e-02" rms="8.2929916381835938e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.6287403181195259e-02" rms="7.5624308586120605e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="1" Cut="1.5827878952026367e+01" cType="1" res="1.8270723819732666e+00" rms="9.5309085845947266e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-4.6995294094085693e-01" rms="9.8379726409912109e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.4742108583450317e-01" rms="9.0492343902587891e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="9" Cut="5.9372216463088989e-01" cType="1" res="6.4135670661926270e-01" rms="8.1981534957885742e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="8" Cut="5.4655432701110840e-02" cType="1" res="5.0737565755844116e-01" rms="8.1676893234252930e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.1926695257425308e-02" rms="8.1929998397827148e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.2019436359405518e-01" rms="7.5053734779357910e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7760025262832642e+00" rms="3.2477447986602783e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+      </Node>
+    </BinaryTree>
+    <BinaryTree type="DecisionTree" boostWeight="1.0000000000000000e+00" itree="199">
+      <Node pos="s" depth="0" NCoef="0" IVar="9" Cut="5.7847630977630615e-01" cType="1" res="-9.8342141136527061e-03" rms="7.9769368171691895e+00" purity="1.0000000000000000e+00" nType="0">
+        <Node pos="l" depth="1" NCoef="0" IVar="11" Cut="8.4034144878387451e-01" cType="1" res="-3.0584034323692322e-01" rms="8.2080106735229492e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="15" Cut="6.4129028320312500e+00" cType="1" res="-3.3087503910064697e-01" rms="8.1984281539916992e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-5.9157148003578186e-02" rms="8.1953744888305664e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="7.5854545831680298e-01" rms="7.4616703987121582e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.7618852853775024e+00" rms="8.3607778549194336e+00" purity="1.0000000000000000e+00" nType="-99"/>
+        </Node>
+        <Node pos="r" depth="1" NCoef="0" IVar="11" Cut="4.0571305155754089e-01" cType="1" res="2.5695216655731201e-01" rms="7.7531051635742188e+00" purity="1.0000000000000000e+00" nType="0">
+          <Node pos="l" depth="2" NCoef="0" IVar="3" Cut="2.0886163330078125e+02" cType="1" res="1.4808088541030884e-01" rms="7.7399115562438965e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="-7.1953311562538147e-03" rms="7.6826920509338379e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="9.0218836069107056e-01" rms="9.2038002014160156e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+          <Node pos="r" depth="2" NCoef="0" IVar="11" Cut="4.3023812770843506e-01" cType="1" res="5.2537689208984375e+00" rms="6.6317548751831055e+00" purity="1.0000000000000000e+00" nType="0">
+            <Node pos="l" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="3.3059576153755188e-01" rms="6.9466896057128906e+00" purity="1.0000000000000000e+00" nType="-99"/>
+            <Node pos="r" depth="3" NCoef="0" IVar="-1" Cut="0.0000000000000000e+00" cType="1" res="1.5697776079177856e+00" rms="3.2809801101684570e+00" purity="1.0000000000000000e+00" nType="-99"/>
+          </Node>
+        </Node>
+      </Node>
+    </BinaryTree>
+  </Weights>
+</MethodSetup>

--- a/README.md
+++ b/README.md
@@ -23,4 +23,4 @@ For now, make .so libraries by hand in ROOT
 
 cd VHbbAnalysis
 
-python RunAnalysis.py
+python RunAnalysis.py vhbb_config.txt

--- a/VHbbAnalysis/cfg/existingbranches.txt
+++ b/VHbbAnalysis/cfg/existingbranches.txt
@@ -8,9 +8,13 @@ type=8  name=selLeptons_relIso03                max=10
 type=6  name=selLeptons_pdgId                   max=10
 type=6  name=selLeptons_eleCutIdCSA14_25ns_v1   max=10
 
-#type=3  name=HVdPhi
+type=3  name=H_mass                            
+type=3  name=H_pt
+type=3  name=V_pt
+type=3  name=HVdPhi
 type=3  name=met_pt
 type=3  name=met_phi
+type=3  name=met_sumEt
 
 type=1  name=naLeptons
 type=8  name=aLeptons_pt                        max=50
@@ -19,6 +23,7 @@ type=6  name=aLeptons_pdgId                     max=50
 type=8  name=aLeptons_relIso03                  max=50
 type=6  name=aLeptons_eleCutIdCSA14_25ns_v1     max=50
 
+type=1  name=naJets
 
 type=6  name=Jet_id                             max=100
 type=6  name=Jet_puId                           max=100
@@ -27,3 +32,31 @@ type=8  name=Jet_btagCSV                        max=100
 type=8  name=Jet_pt                             max=100
 type=8  name=Jet_eta                            max=100
 type=8  name=Jet_phi                            max=100
+
+# variables needed for the jet energy regression, maybe we can find a way to
+# not save these?
+type=8  name=hJets_pt                           max=100
+type=8  name=hJets_rawPt                        max=100
+type=8  name=hJets_eta                          max=100
+type=8  name=hJets_mass                         max=100
+type=8  name=hJets_leadTrackPt                  max=100
+type=8  name=hJets_leptonPtRel                  max=100
+type=8  name=hJets_leptonPt                     max=100
+type=8  name=hJets_leptonDeltaR                 max=100
+type=8  name=hJets_chEmEF                       max=100
+type=8  name=hJets_chHEF                        max=100
+type=8  name=hJets_neHEF                        max=100
+type=8  name=hJets_neEmEF                       max=100
+type=8  name=hJets_chMult                       max=100
+type=8  name=hJets_puId                         max=100
+type=8  name=hJets_vtxMass                      max=100
+type=8  name=hJets_vtx3DVal                     max=100
+type=8  name=hJets_vtxNtracks                   max=100
+type=8  name=hJets_vtxPt                        max=100
+type=8  name=hJets_phi                          max=100
+type=8  name=hJets_btagCSV                      max=100
+
+type=8  name=aJets_pt                           max=100
+type=8  name=aJets_eta                          max=100
+type=8  name=aJets_btagCSV                      max=100
+

--- a/VHbbAnalysis/cfg/newbranches.txt
+++ b/VHbbAnalysis/cfg/newbranches.txt
@@ -16,3 +16,16 @@ type=2  name=Vtype_f
 type=2  name=absDeltaPullAngle
 type=2  name=highestCSVaJet
 type=2  name=minDeltaRaJet
+
+# jet energy regression variables
+type=2  name=Jet1_pt_reg
+type=2  name=Jet2_pt_reg
+type=2  name=H_mass_reg
+type=2  name=H_pt_reg
+type=2  name=H_eta_reg
+type=2  name=H_phi_reg
+type=2  name=H_dR_reg
+type=2  name=H_dPhi_reg
+type=2  name=H_dEta_reg
+type=2  name=Jet1_regWeight
+type=2  name=Jet2_regWeight

--- a/VHbbAnalysis/cfg/regression_settings.txt
+++ b/VHbbAnalysis/cfg/regression_settings.txt
@@ -1,0 +1,26 @@
+# type 0 -> Spectator variable
+# type 1 -> Variable used in BDT training
+
+bdtname="Jet_pt_regression"
+#xmlFile=../JetEnergyRegression/weights/Wln_noMET.xml
+xmlFile=../JetEnergyRegression/weights/new-weights-23Jan.xml 
+
+name=Jet_pt              lname=hJets_pt            type=1 order=1
+#name=Jet_rawPt           lname=hJets_rawPt         type=1 order=2
+name=rho                 lname=rho                 type=1 order=3
+name=Jet_eta             lname=hJets_eta           type=1 order=4
+name=Jet_mt              lname=hJets_mt            type=1 order=5
+name=Jet_leadTrackPt     lname=hJets_leadTrackPt   type=1 order=6
+name=Jet_leptonPtRel     lname=hJets_leptonPtRel   type=1 order=7
+name=Jet_leptonPt        lname=hJets_leptonPt      type=1 order=8
+name=Jet_leptonDeltaR    lname=hJets_leptonDeltaR  type=1 order=9
+name=Jet_chEmEF          lname=hJets_chEmEF        type=1 order=10
+name=Jet_chHEF           lname=hJets_chHEF         type=1 order=11
+name=Jet_neHEF           lname=hJets_neHEF         type=1 order=12
+name=Jet_neEmEF          lname=hJets_neEmEF        type=1 order=13
+name=Jet_chMult          lname=hJets_chMult        type=1 order=14
+#name=Jet_puId            lname=hJets_puId          type=1 order=15
+name=Jet_vtxPt           lname=hJets_vtxPt         type=1 order=15
+name=Jet_vtxMass         lname=hJets_vtxMass       type=1 order=16
+name=Jet_vtx3dL          lname=hJets_vtx3DVal      type=1 order=17
+name=Jet_vtxNtrk         lname=hJets_vtxNtracks    type=1 order=18

--- a/VHbbAnalysis/vhbb_config.txt
+++ b/VHbbAnalysis/vhbb_config.txt
@@ -1,10 +1,13 @@
 analysis=VHbbAnalysis
 outputname=output
 
-samples=cfg/samples_heppytest_dec2014.txt
+samples=cfg/samples_heppytest_dec2014_lpc.txt
 
 earlybranches=cfg/earlybranches.txt
 existingbranches=cfg/existingbranches.txt
 newbranches=cfg/newbranches.txt
 
+bdtsettings=cfg/bdtsettings.txt
+reg1settings=cfg/reg1_settings.txt
+reg2settings=cfg/reg2_settings.txt
 settings=cfg/settings.txt

--- a/env.csh
+++ b/env.csh
@@ -1,0 +1,4 @@
+
+setenv PYTHONPATH $PWD/python:$PYTHONPATH
+setenv LD_LIBRARY_PATH ${LD_LIBRARY_PATH}:$PWD
+setenv LD_LIBRARY_PATH ${LD_LIBRARY_PATH}:$PWD/HelperClasses:$PWD/plugins:$PWD/python

--- a/plugins/VHbbAnalysis.cc
+++ b/plugins/VHbbAnalysis.cc
@@ -7,6 +7,8 @@
 
 #include "VHbbAnalysis.h"
 
+#include "TLorentzVector.h"
+
 // initialize parameters
 VHbbAnalysis::VHbbAnalysis(){
     if(debug>10) std::cout<<"Constructing VHbbAnalysis"<<std::endl;
@@ -71,21 +73,127 @@ bool VHbbAnalysis::Analyze(){
 void VHbbAnalysis::FinishEvent(){
     *in["sampleIndex"] = cursample->sampleNum;
     *f["weight"] = cursample->intWeight;
-    
     *f["Vtype_f"] = (float) *d["Vtype"];
     //*f["absDeltaPullAngle"] = fabs(*f["deltaPullAngle"]);
     *f["naLeptonsPassingCuts"] = 0.;
-    //for(int j=0;j<*in["naLeptons"]&&j<100;j++){
-    //    //if(f["aLepton_pt"][j]>15. && fabs(f["aLepton_eta"][j])<2.5 && f["aLepton_pfCombRelIso"][j]<0.15) *f["naLeptonsPassingCuts"] += 1.;
-    //    if(f["aLepton_pt"][j]>15. && fabs(f["aLepton_eta"][j])<2.5 && f["aLeptons_eleCutIdCSA14_25ns_v1"][j]) *f["naLeptonsPassingCuts"] += 1.;
-    //}
-    //*f["naJetsPassingCuts"] = 0.;
-    //*f["highestCSVaJet"] = 0.0;
-    //*f["minDeltaRaJet"] = 9999.0;
-    //for(int j=0;j<*in["naJets"];j++){
-    //    if(f["aJet_pt"][j]>20. && fabs(f["aJet_eta"][j])<4.5) *f["naJetsPassingCuts"] += 1;
-    //}       
+    for(int j=0;j<*in["naLeptons"]&&j<100;j++){
+        //if(f["aLepton_pt"][j]>15. && fabs(f["aLepton_eta"][j])<2.5 && f["aLepton_pfCombRelIso"][j]<0.15) *f["naLeptonsPassingCuts"] += 1.;
+        if(d["aLeptons_pt"][j]>15. && fabs(d["aLeptons_eta"][j])<2.5 && in["aLeptons_eleCutIdCSA14_25ns_v1"][j]) *f["naLeptonsPassingCuts"] += 1.;
+    }
+    *f["naJetsPassingCuts"] = 0.;
+    *f["highestCSVaJet"] = 0.0;
+    *f["minDeltaRaJet"] = 9999.0; // FIXME add correct initialization
+    for(int j=0;j<*in["naJets"];j++){
+        if(d["aJets_pt"][j]>20. && fabs(d["aJets_eta"][j])<4.5) *f["naJetsPassingCuts"] += 1;
+        if(d["aJets_pt"][j]>20 && fabs(d["aJets_eta"][j])<2.5 && d["aJets_btagCSV"][j]>*f["highestCSVaJet"]) *f["highestCSVaJet"] = d["aJets_btagCSV"][j];
+      }       
     
+    // Set variables used by the BDT
+    *f["H_mass_f"] = (float) *d["H_mass"];
+    *f["H_pt_f"] = (float) *d["H_pt"];
+    *f["V_pt_f"] = (float) *d["V_pt"];
+    *f["hJets_btagCSV_0"] = (float) d["hJets_btagCSV"][0];
+    *f["hJets_btagCSV_1"] = (float) d["hJets_btagCSV"][1]; 
+    *f["HVdPhi_f"] = (float) *d["HVdPhi"];
+    *f["H_dEta"] = fabs(d["hJets_eta"][0] - d["hJets_eta"][1]);
+    
+    TLorentzVector hJ1 = TLorentzVector();
+    TLorentzVector hJ2 = TLorentzVector();
+    hJ1.SetPtEtaPhiM(d["hJets_pt"][0], d["hJets_eta"][0], d["hJets_phi"][0], d["hJets_mass"][0]);
+    hJ2.SetPtEtaPhiM(d["hJets_pt"][1], d["hJets_eta"][0], d["hJets_phi"][1], d["hJets_mass"][1]);
+    *f["hJets_mt_0"] = hJ1.Mt();
+    *f["hJets_mt_1"] = hJ2.Mt();
+    *f["H_dR"] = (float) hJ1.DeltaR(hJ2);   
+    *f["absDeltaPullAngle"] = 0.; //FIXME what is this in the new ntuples??
+    *f["hJet_ptCorr_0"] = (float) d["hJets_pt"][0];
+    *f["hJet_ptCorr_1"] = (float) d["hJets_pt"][1];
+    *f["met_sumEt_f"] = (float) *d["met_sumEt"]; // is this the right variable??
+ 
+    for (unsigned int i=0; i<bdtInfos.size(); i++) {
+
+       BDTInfo tmpBDT = bdtInfos[i];
+       if(debug>5000) {
+           PrintBDTInfoValues(tmpBDT);
+           std::cout<<"BDT evaulates to: "<<tmpBDT.reader->EvaluateMVA(tmpBDT.bdtname)<<std::endl;
+       }
+       *f[tmpBDT.bdtname] = tmpBDT.reader->EvaluateMVA(tmpBDT.bdtname);
+    }
+
+    if(jet1EnergyRegressionIsSet && jet2EnergyRegressionIsSet) {
+        *f["hJets_pt_0"] = float(d["hJets_pt"][0]);
+        //*f["hJets_rawPt_0"] = float(d["hJets_rawPt"][0]);
+        *f["hJets_eta_0"] = float(d["hJets_eta"][0]);
+        //*f["hJets_mt_0"] = 0.; // FIXME
+        *f["hJets_leadTrackPt_0"] = float(d["hJets_leadTrackPt"][0]);
+        *f["hJets_leptonPtRel_0"] = float(d["hJets_leptonPtRel"][0]);
+        *f["hJets_leptonPt_0"] = float(d["hJets_leptonPt"][0]);
+        *f["hJets_leptonDeltaR_0"] = float(d["hJets_leptonDeltaR"][0]);
+        *f["hJets_chEmEF_0"] = float(d["hJets_chEmEF"][0]);
+        *f["hJets_chHEF_0"] = float(d["hJets_chHEF"][0]);
+        *f["hJets_neHEF_0"] = float(d["hJets_neHEF"][0]);
+        *f["hJets_neEmEF_0"] = float(d["hJets_neEmEF"][0]);
+        *f["hJets_chMult_0"] = float(d["hJets_chMult"][0]);
+        //*f["hJets_puId_0"] = float(d["hJets_puId"][0]);
+        *f["hJets_vtx3DVal_0"] = 0.;
+        *f["hJets_vtxNtracks_0"] = 0.;
+        *f["hJets_vtxMass_0"] = float(d["hJets_vtxMass"][0]);
+        *f["hJets_vtxPt_0"] = float(d["hJets_vtxPt"][0]);
+        *f["hJets_vtx3DVal_0"] = float(d["hJets_vtx3DVal"][0]);
+        *f["hJets_vtxNtracks_0"] = float(d["hJets_vtxNtracks"][0]);
+
+        *f["hJets_pt_1"] = float(d["hJets_pt"][1]);
+        //*f["hJets_rawPt_1"] = float(d["hJets_rawPt"][1]);
+        *f["hJets_eta_1"] = float(d["hJets_eta"][1]);
+        //*f["hJets_mt_1"] = 0.; // FIXME
+        *f["hJets_leadTrackPt_1"] = float(d["hJets_leadTrackPt"][1]);
+        *f["hJets_leptonPtRel_1"] = float(d["hJets_leptonPtRel"][1]);
+        *f["hJets_leptonPt_1"] = float(d["hJets_leptonPt"][1]);
+        *f["hJets_leptonDeltaR_1"] = float(d["hJets_leptonDeltaR"][1]);
+        *f["hJets_chEmEF_1"] = float(d["hJets_chEmEF"][1]);
+        *f["hJets_chHEF_1"] = float(d["hJets_chHEF"][1]);
+        *f["hJets_neHEF_1"] = float(d["hJets_neHEF"][1]);
+        *f["hJets_neEmEF_1"] = float(d["hJets_neEmEF"][1]);
+        *f["hJets_chMult_1"] = float(d["hJets_chMult"][1]);
+        //*f["hJets_puId_1"] = float(d["hJets_puId"][1]);
+        *f["hJets_vtx3DVal_1"] = 0.;
+        *f["hJets_vtxNtracks_1"] = 0.;
+        *f["hJets_vtxMass_1"] = float(d["hJets_vtxMass"][1]);
+        *f["hJets_vtx3DVal_1"] = float(d["hJets_vtx3DVal"][1]);
+        *f["hJets_vtxPt_1"] = float(d["hJets_vtxPt"][1]);
+        *f["hJets_vtxNtracks_1"] = float(d["hJets_vtxNtracks"][1]);
+        
+        if(debug>10000) {
+            std::cout<<"Evaluating the Jet Energy Regression..."<<std::endl;
+            PrintBDTInfoValues(jet1EnergyRegression);
+            PrintBDTInfoValues(jet2EnergyRegression);
+        }
+        double r1Pt = jet1EnergyRegression.reader->EvaluateRegression(jet1EnergyRegression.bdtname)[0];
+        double r2Pt = jet2EnergyRegression.reader->EvaluateRegression(jet2EnergyRegression.bdtname)[0];
+
+        *f["Jet1_regWeight"] = r1Pt/(*f["hJets_pt_0"]);
+        *f["Jet2_regWeight"] = r2Pt/(*f["hJets_pt_1"]);
+
+        TLorentzVector hJ1_reg = TLorentzVector();
+        TLorentzVector hJ2_reg = TLorentzVector();
+ 
+        *f["Jet1_pt_reg"] = r1Pt;
+        *f["Jet2_pt_reg"] = r2Pt;
+        hJ1_reg.SetPtEtaPhiM(r1Pt, *f["hJets_eta_0"], d["hJets_phi"][0], d["hJets_mass"][0]);
+        hJ2_reg.SetPtEtaPhiM(r2Pt, *f["hJets_eta_1"], d["hJets_phi"][1], d["hJets_mass"][1]);
+       
+        //*f["hJets_mt_0"] = hJ1_reg.Mt();
+        //*f["hJets_mt_1"] = hJ2_reg.Mt();
+    
+        TLorentzVector H_vec_reg = hJ1_reg + hJ2_reg;
+        *f["H_mass_reg"] = H_vec_reg.M();
+        *f["H_pt_reg"] = H_vec_reg.Pt();
+        *f["H_eta_reg"] = H_vec_reg.Eta();
+        *f["H_phi_reg"] = H_vec_reg.Phi();
+        *f["H_dR_reg"] = hJ1_reg.DeltaR(hJ2_reg);
+        *f["H_dPhi_reg"] = hJ1_reg.DeltaPhi(hJ2_reg);
+        *f["H_dEta_reg"] = fabs(hJ1_reg.Eta() - hJ2_reg.Eta() );
+     }
+
     ofile->cd();
     outputTree->Fill();
     return;
@@ -99,7 +207,6 @@ void VHbbAnalysis::TermAnalysis(){
     if(debug>10) std::cout<<"DONE TermAnalysis()"<<std::endl;
     return;
 }
-
 
 bool VHbbAnalysis::WenuHbbSelection(){
     int selectedInd=-1;
@@ -130,13 +237,11 @@ bool VHbbAnalysis::WenuHbbSelection(){
     return selectEvent;
 }
 
-
 bool VHbbAnalysis::WmunuHbbSelection(){
     bool sel=false;
     //if(1) sel=true;
     return sel;
 }
-
 
 std::pair<int,int> VHbbAnalysis::HighestPtBJets(){
     std::pair<int,int> pair(-1,-1);


### PR DESCRIPTION
Hi Chris,

Here's a working version which includes the jet energy corrections. A few of the input variables for the regression don't seem to be in our ntuples so, as you'll see in the code, I currently have these initialized to 0. We'll have to fix that of course. 

In order to use some of the variables as input for the regression, I had to add them to our list of existing branches. We need for example, 'hJets_rawPt[0]' and 'hJets_rawPt[1]' as inputs, so I added the array variable 'hJets_rawPt' as an existing branch. We don't necessarily need to save its value in the output tree though, maybe we can come up with a way to declare whether a variable should be saved in the output tree (saved=1/0 or something).

Adding the BDT discriminator is just a matter of figuring out which variables in the ntuples correspond to those used in training, I'm working on that now. Otherwise, the code for that should be included as well in this pull request. The config file for the BDT settings is still a work in progress, so I left it out.

Best,
Stephane